### PR TITLE
Fix exception when creating EthAction object

### DIFF
--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -63,7 +63,9 @@ def _sign_transaction(rpc_client, async_job, unsigned_tx):
 
     # Create EthAction so this Job's Listeners can also listen to Events posted for the TransactionHash
     with transaction.atomic():
-        eth_action = EthAction(async_job=async_job, transaction_hash=hash_tx)
+        eth_action, _ = EthAction.objects.update_or_create(transaction_hash=hash_tx, defaults={
+            'async_job': async_job
+        })
         for job_listener in async_job.joblistener_set.all():
             eth_action.ethlistener_set.create(listener=job_listener.listener)
 


### PR DESCRIPTION
AsyncJob tasks currently fail in some scenarios due to the following exception:
`psycopg2.IntegrityError: null value in column "created_at" violates not-null constraint`

The fix is to use update_or_create within the database transaction: https://stackoverflow.com/a/51279573