### PR TITLE
Use correct async_job.id when returning job from shipment.

### DIFF
--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -89,10 +89,9 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
 
         shipment = self.perform_update(serializer)
-        async_job = shipment.asyncjob_set.all()[:1]  # TODO: be sure to filter to the latest one, handle race cond.
-
+        async_job = shipment.asyncjob_set.latest('created_at')
         response = ShipmentTxSerializer(shipment)
         if async_job:
-            response.instance.async_job_id = async_job[0].id
+            response.instance.async_job_id = async_job.id
 
         return Response(response.data, status=status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
When updating a shipment, the return field contains an asyncjob_id. Originally, it was possible that this could return the async_job for the creation of the shipment instead of the new one for the update. With this hotfix, it should now return the correct async_job of the update_vault_hash_transaction.