### PR TITLE
Feature/metrics reporting

### DIFF
--- a/apps/eth/rpc.py
+++ b/apps/eth/rpc.py
@@ -1,10 +1,18 @@
+import logging
+
 from apps.eth.models import Event
 from apps.rpc_client import RPCClient, RPCError
+from influxdb_metrics.loader import log_metric
+
+
+LOG = logging.getLogger('transmission')
 
 
 class EventRPCClient(RPCClient):
 
     def subscribe(self, url=Event.get_event_subscription_url(), project="LOAD", interval=5000, events=None):
+        LOG.debug(f'Event subscription with url {url}.')
+        log_metric('transmission.info', tags={'method': 'event.subscribe'})
 
         result = self.call('event.subscribe', {
             "url": url,

--- a/apps/eth/rpc.py
+++ b/apps/eth/rpc.py
@@ -12,7 +12,8 @@ class EventRPCClient(RPCClient):
 
     def subscribe(self, url=Event.get_event_subscription_url(), project="LOAD", interval=5000, events=None):
         LOG.debug(f'Event subscription with url {url}.')
-        log_metric('transmission.info', tags={'method': 'eth.rpcclient.subscribe'})
+        log_metric('transmission.info', tags={'method': 'event_rpcclient.subscribe',
+                                              'package': 'eth.rpc'})
 
         result = self.call('event.subscribe', {
             "url": url,
@@ -25,4 +26,6 @@ class EventRPCClient(RPCClient):
             if 'subscription' in result:
                 return
 
+        log_metric('transmission.error', tags={'method': 'event_rpcclient.subscribe', 'code': 'RPCError',
+                                               'package': 'eth.rpc'})
         raise RPCError("Invalid response from Engine")

--- a/apps/eth/rpc.py
+++ b/apps/eth/rpc.py
@@ -12,7 +12,7 @@ class EventRPCClient(RPCClient):
 
     def subscribe(self, url=Event.get_event_subscription_url(), project="LOAD", interval=5000, events=None):
         LOG.debug(f'Event subscription with url {url}.')
-        log_metric('transmission.info', tags={'method': 'event.subscribe'})
+        log_metric('transmission.info', tags={'method': 'eth.rpcclient.subscribe'})
 
         result = self.call('event.subscribe', {
             "url": url,

--- a/apps/eth/signals.py
+++ b/apps/eth/signals.py
@@ -13,12 +13,12 @@ LOG = logging.getLogger('transmission')
 
 @receiver(post_save, sender=Event, dispatch_uid='event_post_save')
 def event_post_save(sender, instance, **kwargs):
-    LOG.debug(f'Event post save with sender {sender}.')
-    log_metric('transmission.info', tags={'method': 'event_post_save'})
+    LOG.debug(f'Event post save with id {instance.id}.')
+    log_metric('transmission.info', tags={'method': 'eth.event_post_save'})
 
     # Update has been received, send signal to listener class
     if instance.eth_action:
-        LOG.debug(f'Update has been received, and signal sent.')
+        LOG.debug(f'Sending signals to all listeners for EthAction {instance.eth_action.id}.')
         for listener in instance.eth_action.ethlistener_set.all():
             event_update.send(sender=listener.listener_type.model_class(),
                               event=instance, listener=listener.listener)

--- a/apps/eth/signals.py
+++ b/apps/eth/signals.py
@@ -2,7 +2,6 @@ import logging
 
 from django.db.models.signals import post_save
 from django.dispatch import Signal, receiver
-from influxdb_metrics.loader import log_metric
 
 # pylint:disable=invalid-name
 from apps.eth.models import Event

--- a/apps/eth/signals.py
+++ b/apps/eth/signals.py
@@ -1,17 +1,24 @@
+import logging
+
 from django.db.models.signals import post_save
 from django.dispatch import Signal, receiver
+from influxdb_metrics.loader import log_metric
 
 # pylint:disable=invalid-name
 from apps.eth.models import Event
 
 event_update = Signal(providing_args=["event", "listener"])
+LOG = logging.getLogger('transmission')
 
 
 @receiver(post_save, sender=Event, dispatch_uid='event_post_save')
 def event_post_save(sender, instance, **kwargs):
+    LOG.debug(f'Event post save with sender {sender}.')
+    log_metric('transmission.info', tags={'method': 'event_post_save'})
 
     # Update has been received, send signal to listener class
     if instance.eth_action:
+        LOG.debug(f'Update has been received, and signal sent to listener {listener}.')
         for listener in instance.eth_action.ethlistener_set.all():
             event_update.send(sender=listener.listener_type.model_class(),
                               event=instance, listener=listener.listener)

--- a/apps/eth/signals.py
+++ b/apps/eth/signals.py
@@ -14,7 +14,6 @@ LOG = logging.getLogger('transmission')
 @receiver(post_save, sender=Event, dispatch_uid='event_post_save')
 def event_post_save(sender, instance, **kwargs):
     LOG.debug(f'Event post save with id {instance.id}.')
-    log_metric('transmission.info', tags={'method': 'eth.event_post_save'})
 
     # Update has been received, send signal to listener class
     if instance.eth_action:

--- a/apps/eth/signals.py
+++ b/apps/eth/signals.py
@@ -18,7 +18,7 @@ def event_post_save(sender, instance, **kwargs):
 
     # Update has been received, send signal to listener class
     if instance.eth_action:
-        LOG.debug(f'Update has been received, and signal sent to listener {listener}.')
+        LOG.debug(f'Update has been received, and signal sent.')
         for listener in instance.eth_action.ethlistener_set.all():
             event_update.send(sender=listener.listener_type.model_class(),
                               event=instance, listener=listener.listener)

--- a/apps/eth/tasks.py
+++ b/apps/eth/tasks.py
@@ -1,20 +1,26 @@
+import logging
+
 from celery import shared_task
 from celery_once import QueueOnce
 from rest_framework.exceptions import APIException
+from influxdb_metrics.loader import log_metric
+
+
+LOG = logging.getLogger('transmission')
 
 
 @shared_task(base=QueueOnce, once={'graceful': True}, bind=True, autoretry_for=(APIException,),
              retry_backoff=3, retry_backoff_max=60, max_retries=None)
 def engine_subscribe(self):
     from apps.eth.rpc import EventRPCClient, RPCError
+    log_metric('transmission.info', tags={'method': 'engine_subscribe'})
 
     try:
         rpc_client = EventRPCClient()
         rpc_client.subscribe()
-        # TODO: Metrics/Logs for subscribe successful
-        print("Subscribed to Events")
+        LOG.debug('Subscribed to events successfully with the rpc_client.')
 
     except RPCError as rpc_error:
         # TODO: Metrics/Logs for subscribe failure
-        print(f"Unable to subscribe to Events: {rpc_error}")
+        LOG.error('Unable to subscribe to Events: {rpc_error}.')
         raise rpc_error

--- a/apps/eth/tasks.py
+++ b/apps/eth/tasks.py
@@ -13,7 +13,8 @@ LOG = logging.getLogger('transmission')
              retry_backoff=3, retry_backoff_max=60, max_retries=None)
 def engine_subscribe(self):
     from apps.eth.rpc import EventRPCClient, RPCError
-    log_metric('transmission.info', tags={'method': 'engine_subscribe'})
+    log_metric('transmission.info', tags={'method': 'eth.engine_subscribe',
+                                          'package': 'eth.tasks'})
 
     try:
         rpc_client = EventRPCClient()
@@ -21,6 +22,7 @@ def engine_subscribe(self):
         LOG.debug('Subscribed to events successfully with the rpc_client.')
 
     except RPCError as rpc_error:
-        # TODO: Metrics/Logs for subscribe failure
+        log_metric('transmission.info', tags={'method': 'eth.engine_subscribe', 'code': 'RPCError',
+                                              'package': 'eth.tasks'})
         LOG.error('Unable to subscribe to Events: {rpc_error}.')
         raise rpc_error

--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -28,7 +28,7 @@ class EventViewSet(mixins.CreateModelMixin,
     permission_classes = (permissions.AllowAny,)
 
     def create(self, request, *args, **kwargs):
-        log_metric('transmission.info', tags={'method': 'eth.events.create'})
+        log_metric('transmission.info', tags={'method': 'events.create', 'package': 'eth.views'})
         LOG.debug('Events create')
 
         is_many = isinstance(request.data, list)
@@ -44,6 +44,8 @@ class EventViewSet(mixins.CreateModelMixin,
             except ObjectDoesNotExist:
                 action = None
                 # TODO: Events without Receipt metric reporting
+                log_metric('transmission.error', tags={'method': 'events.create', 'code': 'object_does_not_exist',
+                                                       'package': 'eth.views', 'detail': 'events.is_many is false'})
                 LOG.info(f"Non-EthAction Event processed "
                          f"Tx: {serializer.data['transaction_hash']}")
 
@@ -60,6 +62,8 @@ class EventViewSet(mixins.CreateModelMixin,
                     action = EthAction.objects.get(transaction_hash=event['transaction_hash'])
                 except ObjectDoesNotExist:
                     action = None
+                    log_metric('transmission.error', tags={'method': 'events.create', 'code': 'object_does_not_exist',
+                                                           'package': 'eth.views', 'detail': 'events.is_many is true'})
                     # TODO: Events without Receipt metric reporting
                     LOG.info(f"Non-EthAction Event processed "
                              f"Tx: {event['transaction_hash']}")
@@ -79,7 +83,7 @@ class TransactionViewSet(mixins.RetrieveModelMixin,
     permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL else (permissions.AllowAny,)
 
     def get_queryset(self):
-        log_metric('transmission.info', tags={'method': 'transaction.get_queryset'})
+        log_metric('transmission.info', tags={'method': 'transaction.get_queryset', 'package': 'eth.transaction'})
         LOG.debug('Getting tx details for a transaction hash.')
         queryset = self.queryset
         if settings.PROFILES_URL:

--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -28,7 +28,7 @@ class EventViewSet(mixins.CreateModelMixin,
     permission_classes = (permissions.AllowAny,)
 
     def create(self, request, *args, **kwargs):
-        log_metric('transmission.info', tags={'method': 'events.create'})
+        log_metric('transmission.info', tags={'method': 'eth.events.create'})
         LOG.debug('Events create')
 
         is_many = isinstance(request.data, list)
@@ -39,7 +39,7 @@ class EventViewSet(mixins.CreateModelMixin,
             serializer.is_valid(raise_exception=True)
 
             try:
-                LOG.debug(f'Finding contract receipt for t-hash: {serializer.validated_data["transactionHash"]}')
+                LOG.debug(f'Finding contract receipt for tx hash: {serializer.data["transactionHash"]}')
                 action = EthAction.objects.get(transaction_hash=serializer.data['transaction_hash'])
             except ObjectDoesNotExist:
                 action = None
@@ -56,7 +56,7 @@ class EventViewSet(mixins.CreateModelMixin,
 
             for event in serializer.data:
                 try:
-                    LOG.debug(f'Finding contract receipt for t-hash: {serializer.validated_data["transactionHash"]}')
+                    LOG.debug(f'Finding contract receipt for tx hash: {serializer.event["transactionHash"]}')
                     action = EthAction.objects.get(transaction_hash=event['transaction_hash'])
                 except ObjectDoesNotExist:
                     action = None

--- a/apps/jobs/signals.py
+++ b/apps/jobs/signals.py
@@ -33,6 +33,6 @@ def message_post_save(sender, instance, **kwargs):
 
     # Update has been received, send signal to listener class
     for listener in instance.async_job.joblistener_set.all():
-        LOG.debug(f'Update has been received, and signal sent to listener {listener}.')
+        LOG.debug(f'Update has been received, and signal sent to listener {instance.id}.')
         job_update.send(sender=listener.listener_type.model_class(),
                         message=instance, listener=listener.listener)

--- a/apps/jobs/signals.py
+++ b/apps/jobs/signals.py
@@ -27,7 +27,7 @@ def message_post_save(sender, instance, **kwargs):
                     f'job {instance.async_job.id} received message {instance.id}')
     if instance.type == MessageType.ERROR:
         # Generic error handling
-        logging.error(f"Transaction failure for AsyncJob {instance.async_job.id}: {instance.body}")
+        LOG.error(f"Transaction failure for AsyncJob {instance.async_job.id}: {instance.body}")
         instance.async_job.state = JobState.FAILED
         instance.async_job.save()
 

--- a/apps/jobs/signals.py
+++ b/apps/jobs/signals.py
@@ -16,8 +16,8 @@ LOG = logging.getLogger('transmission')
 
 @receiver(post_save, sender=Message, dispatch_uid='message_post_save')
 def message_post_save(sender, instance, **kwargs):
-    LOG.debug(f'Message post save with sender {sender}.')
-    log_metric('transmission.info', tags={'method': 'message_post_save'})
+    LOG.debug(f'Message post save with message {instance.id}.')
+    log_metric('transmission.info', tags={'method': 'jobs.message_post_save'})
     try:
         wallet_lock = cache.lock(instance.async_job.parameters['signing_wallet_id'])
         wallet_lock.local.token = instance.async_job.wallet_lock_token

--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -28,7 +28,7 @@ class AsyncTask:
         self.rpc_client = getattr(module, rpc_class_name)()
 
     def run(self):
-        log_metric('transmission.info', tags={'method': 'run'})
+        log_metric('transmission.info', tags={'method': 'async_task.run', 'package': 'jobs.tasks'})
         from .models import JobState
         if self.async_job.state not in (JobState.RUNNING, JobState.COMPLETE):
             LOG.debug(f'Job {self.async_job.id} running with status {self.async_job.state}')
@@ -45,13 +45,15 @@ class AsyncTask:
                     wallet_lock.release()
                     raise e
                 LOG.debug(f'Transaction submitted via AsyncJob {self.async_job.id}')
-                log_metric('transmission.info', tags={'method': 'async_job_fire'})
+                log_metric('transmission.info', tags={'method': 'async_job_fire', 'package': 'jobs.tasks'})
             else:  # Could not lock on wallet, transaction already in progress
+                log_metric('transmission.error', tags={'method': 'async_task.run', 'package': 'jobs.tasks',
+                                                       'code': 'wallet_in_use'})
                 raise WalletInUseException(f'Wallet {wallet_id} is currently already in use.')
 
     def _get_transaction(self):
         LOG.debug(f'Getting transaction for job {self.async_job.id}, {self.async_job.parameters["rpc_method"]}')
-        log_metric('transmission.info', tags={'method': '_get_transaction'})
+        log_metric('transmission.info', tags={'method': 'async_task._get_transaction', 'package': 'jobs.tasks'})
         if self.async_job.parameters['rpc_method'] == 'create_shipment_transaction':
             contract_version, unsigned_tx = getattr(self.rpc_client, self.async_job.parameters['rpc_method'])(
                 *self.async_job.parameters['rpc_parameters'])
@@ -65,7 +67,7 @@ class AsyncTask:
 
     def _sign_transaction(self, unsigned_tx):
         LOG.debug(f'Signing transaction for job {self.async_job.id}')
-        log_metric('transmission.info', tags={'method': '_sign_transaction'})
+        log_metric('transmission.info', tags={'method': 'async_task._sign_transaction', 'package': 'jobs.tasks'})
         from apps.eth.models import EthAction, Transaction
 
         signed_tx, hash_tx = getattr(self.rpc_client, 'sign_transaction')(
@@ -88,6 +90,8 @@ class AsyncTask:
                 eth_action.save()
             else:
                 # There is already a transaction with this transaction hash - retry later (get another nonce)
+                log_metric('transmission.error', tags={'method': 'async_task._sign_transaction', 'package': 'jobs.tasks'
+                                                       , 'code': 'transaction_in_progress'})
                 raise TransactionCollisionException(f'A transaction with the hash {hash_tx} is already in progress.')
 
         return signed_tx, eth_action
@@ -96,7 +100,7 @@ class AsyncTask:
         from .models import JobState
         from apps.eth.models import TransactionReceipt
         LOG.debug(f'Sending transaction for job {self.async_job.id}, hash {eth_action.transaction_hash}')
-        log_metric('transmission.info', tags={'method': '_send_transaction'})
+        log_metric('transmission.info', tags={'method': 'async_task._send_transaction', 'package': 'jobs.tasks'})
 
         receipt = getattr(self.rpc_client, 'send_transaction')(signed_tx, self.async_job.get_callback_url())
         with transaction.atomic():
@@ -111,7 +115,7 @@ class AsyncTask:
              retry_backoff=3, retry_backoff_max=60, max_retries=10)
 def async_job_fire(self, async_job_id):
     LOG.debug(f'AsyncJob {async_job_id} firing!')
-    log_metric('transmission.info', tags={'method': 'async_job_fire'})
+    log_metric('transmission.info', tags={'method': 'async_task.async_job_fire', 'package': 'jobs.tasks'})
 
     task = AsyncTask(async_job_id)
     try:
@@ -123,5 +127,7 @@ def async_job_fire(self, async_job_id):
         LOG.info(f"AsyncJob can't be processed yet ({async_job_id}): {tx_ex}")
         raise self.retry(exc=tx_ex, countdown=settings.CELERY_TXHASH_RETRY * random.uniform(0.5, 1.5))  # Jitter
     except RPCError as rpc_error:
+        log_metric('transmission.error', tags={'method': 'async_job_fire', 'package': 'jobs.tasks',
+                                               'code': 'RPCError'})
         LOG.error(f"AsyncJob Exception ({async_job_id}): {rpc_error}")
         raise rpc_error

--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -90,8 +90,8 @@ class AsyncTask:
                 eth_action.save()
             else:
                 # There is already a transaction with this transaction hash - retry later (get another nonce)
-                log_metric('transmission.error', tags={'method': 'async_task._sign_transaction', 'package': 'jobs.tasks'
-                                                       , 'code': 'transaction_in_progress'})
+                log_metric('transmission.error', tags={'method': 'async_task._sign_transaction',
+                                                       'package': 'jobs.tasks', 'code': 'transaction_in_progress'})
                 raise TransactionCollisionException(f'A transaction with the hash {hash_tx} is already in progress.')
 
         return signed_tx, eth_action

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets, mixins, parsers, permissions, status, rende
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework_json_api import parsers as jsapi_parsers
+from influxdb_metrics.loader import log_metric
 
 from .models import AsyncJob
 from .serializers import AsyncJobSerializer, MessageSerializer

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from rest_framework import viewsets, mixins, parsers, permissions, status, renderers
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -6,6 +8,9 @@ from influxdb_metrics.loader import log_metric
 
 from .models import AsyncJob
 from .serializers import AsyncJobSerializer, MessageSerializer
+
+
+LOG = logging.getLogger('transmission')
 
 
 class JobsViewSet(mixins.ListModelMixin,
@@ -22,6 +27,9 @@ class JobsViewSet(mixins.ListModelMixin,
             permission_classes=[permissions.AllowAny],
             renderer_classes=[renderers.JSONRenderer])
     def message(self, request, version, pk):
+        LOG.debug(f'Jobs message called.')
+        log_metric('transmission.info', tags={'method': 'jobs.message'})
+
         serializer = MessageSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -28,7 +28,7 @@ class JobsViewSet(mixins.ListModelMixin,
             renderer_classes=[renderers.JSONRenderer])
     def message(self, request, version, pk):
         LOG.debug(f'Jobs message called.')
-        log_metric('transmission.info', tags={'method': 'jobs.message'})
+        log_metric('transmission.info', tags={'method': 'jobs.message', 'package': 'jobs.views'})
 
         serializer = MessageSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/apps/rpc_client.py
+++ b/apps/rpc_client.py
@@ -21,7 +21,6 @@ class RPCError(APIException):
         super(RPCError, self).__init__(detail, code)
         self.detail = detail
         LOG.error(f'RPC error with detail {detail}.')
-        log_metric('transmission.error', tags={'method': 'RPCError'})
 
         if status_code:
             self.status_code = status_code
@@ -81,6 +80,8 @@ class RPCClient(object):
             if 'transaction' in result:
                 LOG.debug(f'Successful signing of transaction.')
                 return result['transaction'], result['hash']
+
+        log_metric('engine_rpc.error', tags={'method': 'RPCClient.sign_transaction'})
         raise RPCError("Invalid response from Engine")
 
     def send_transaction(self, signed_transaction, callback_url):
@@ -96,4 +97,6 @@ class RPCClient(object):
             if 'receipt' in result:
                 LOG.debug(f'Successful sending of transaction.')
                 return result['receipt']
+
+        log_metric('engine_rpc.error', tags={'method': 'RPCClient.sign_transaction'})
         raise RPCError("Invalid response from Engine")

--- a/apps/shipments/geojson.py
+++ b/apps/shipments/geojson.py
@@ -48,7 +48,7 @@ def build_point_features(shipment, tracking_data):
             if begin <= dtp.timestamp <= end:
                 point_features.append(dtp.as_point_feature())
         except InvalidTrackingPointError as err:
-            LOG.error(f'Error parsing tracking data for shipment {shipment.id}: {err}')
+            LOG.warning(f'Error parsing tracking data for shipment {shipment.id}: {err}')
     point_features.sort(key=lambda dt_feature: dt_feature.properties['time'])
     return point_features
 

--- a/apps/shipments/geojson.py
+++ b/apps/shipments/geojson.py
@@ -94,8 +94,8 @@ class DeviceTrackingPoint(object):
             self.has_gps = point['has_gps'] if 'has_gps' in point else None
             self.source = point['source'] if 'source' in point else None
 
-        except IndexError:
-            LOG.error(f'Device tracking index Error {IndexError}.')
+        except IndexError as index_error:
+            LOG.error(f'Device tracking index Error {index_error}.')
             log_metric('transmission.error', tags={'method': 'device_tracking_index_error',
                                                    'package': 'shipments.geojson', 'code': 'device_tracking_index'})
 
@@ -114,8 +114,8 @@ class DeviceTrackingPoint(object):
 
         try:
             return Point((self.lon, self.lat))
-        except Exception as ex:
-            LOG.error(f'Device tracking as_point exception {ex}.')
+        except Exception as exception:
+            LOG.error(f'Device tracking as_point exception {exception}.')
             log_metric('transmission.error', tags={'method': 'as_point_exception',
                                                    'package': 'shipments.geojson', 'code': 'as_point'})
 
@@ -132,8 +132,8 @@ class DeviceTrackingPoint(object):
                 "has_gps": self.has_gps,
                 "source": self.source,
             })
-        except Exception as ex:
-            LOG.error(f'Device tracking as_point_feature exception {ex}.')
+        except Exception as exception:
+            LOG.error(f'Device tracking as_point_feature exception {exception}.')
             log_metric('transmission.error', tags={'method': 'as_point_feature_exception',
                                                    'package': 'shipments.geojson', 'code': 'as_point_feature'})
 
@@ -155,8 +155,8 @@ class DeviceTrackingPoint(object):
             linestring, linestring_timestamps = DeviceTrackingPoint.get_linestring_list(tracking_points)
             return Feature(geometry=linestring, properties={"linestringTimestamps": linestring_timestamps})
 
-        except Exception as ex:
-            LOG.error(f'Device tracking get_linestring_feature exception {ex}.')
+        except Exception as exception:
+            LOG.error(f'Device tracking get_linestring_feature exception {exception}.')
             log_metric('transmission.error', tags={'method': 'get_linestring_feature'})
 
             raise InvalidTrackingPointError("Unable to build GeoJSON LineString Feature from tracking data")
@@ -188,7 +188,7 @@ class DeviceTrackingPoint(object):
             return datetime(year, month, day, hour, minute, second)
 
         except Exception as exception:
-            LOG.error(f'Device tracking __build_timestamp exception {Exception}.')
+            LOG.error(f'Device tracking __build_timestamp exception {exception}.')
             log_metric('transmission.error', tags={'method': '__build_timestamp_exception',
                                                    'package': 'shipments.geojson', 'code': '__build_timestamp'})
 

--- a/apps/shipments/geojson.py
+++ b/apps/shipments/geojson.py
@@ -3,6 +3,8 @@ from datetime import datetime
 
 from rest_framework.exceptions import APIException
 from geojson import Feature, FeatureCollection, LineString, Point
+from influxdb_metrics.loader import log_metric
+
 
 LOG = logging.getLogger('transmission')
 
@@ -15,6 +17,8 @@ def build_line_string_feature(shipment, tracking_data):
     """
     begin = (shipment.pickup_actual or datetime.min).replace(tzinfo=None)
     end = (shipment.delivery_actual or datetime.max).replace(tzinfo=None)
+    LOG.debug(f'Has object permission with tracking_data {tracking_data}.')
+    log_metric('transmission.info', tags={'method': 'build_line_string_feature'})
     tracking_points = []
     for point in tracking_data:
         try:
@@ -22,7 +26,7 @@ def build_line_string_feature(shipment, tracking_data):
             if begin <= dtp.timestamp <= end:
                 tracking_points.append(dtp)
         except InvalidTrackingPointError as err:
-            LOG.warning(f'Error parsing tracking data for shipment {shipment.id}: {err}')
+            LOG.error(f'Error parsing tracking data for shipment {shipment.id}: {err}')
     tracking_points.sort(key=lambda dt_point: dt_point.timestamp)
     return [DeviceTrackingPoint.get_linestring_feature(tracking_points)]
 
@@ -35,6 +39,8 @@ def build_point_features(shipment, tracking_data):
     """
     begin = (shipment.pickup_actual or datetime.min).replace(tzinfo=None)
     end = (shipment.delivery_actual or datetime.max).replace(tzinfo=None)
+    LOG.debug(f'Build point features with tracking_data {tracking_data}.')
+    log_metric('transmission.info', tags={'method': 'build_point_features'})
     point_features = []
     for point in tracking_data:
         try:
@@ -42,7 +48,7 @@ def build_point_features(shipment, tracking_data):
             if begin <= dtp.timestamp <= end:
                 point_features.append(dtp.as_point_feature())
         except InvalidTrackingPointError as err:
-            LOG.warning(f'Error parsing tracking data for shipment {shipment.id}: {err}')
+            LOG.error(f'Error parsing tracking data for shipment {shipment.id}: {err}')
     point_features.sort(key=lambda dt_feature: dt_feature.properties['time'])
     return point_features
 
@@ -52,6 +58,9 @@ def build_feature_collection(features):
     :param features: List of Features, or single Feature to be returned in a FeatureCollection
     :return: All provided Features in a single FeatureCollection
     """
+    LOG.debug(f'Build feature collection with features {features}.')
+    log_metric('transmission.info', tags={'method': 'build_feature_collection'})
+
     feature_list = features
 
     if not isinstance(feature_list, list):
@@ -64,6 +73,9 @@ class InvalidTrackingPointError(APIException):
     """
     Extend DRF APIException so these are automatically transformed via the exception handler
     """
+    LOG.debug(f'Invalid Tracking Point Error {APIException}.')
+    log_metric('transmission.error', tags={'method': 'invalid_tracking_point_error'})
+
     pass
 
 
@@ -84,18 +96,33 @@ class DeviceTrackingPoint(object):
             self.source = point['source'] if 'source' in point else None
 
         except IndexError:
+            LOG.debug(f'Device tracking index Error {IndexError}.')
+            log_metric('transmission.error', tags={'method': 'device_tracking_index_error'})
+
             raise InvalidTrackingPointError(f"Invalid Coordinates format from device")
 
         except KeyError as key_error:
+            LOG.debug(f'Device tracking key Error {key_error}.')
+            log_metric('transmission.error', tags={'method': 'device_tracking_key_error'})
+
             raise InvalidTrackingPointError(f"Missing field {key_error} in tracking data from device")
 
     def as_point(self):
+        LOG.debug(f'Device tracking as_point.')
+        log_metric('transmission.info', tags={'method': 'as_point'})
+
         try:
             return Point((self.lon, self.lat))
         except Exception:
+            LOG.debug(f'Device tracking as_point exception {Exception}.')
+            log_metric('transmission.error', tags={'method': 'as_point_exception'})
+
             raise InvalidTrackingPointError("Unable to build GeoJSON Point from tracking data")
 
     def as_point_feature(self):
+        LOG.debug(f'Device tracking as_point.')
+        log_metric('transmission.info', tags={'method': 'as_point_feature'})
+
         try:
             return Feature(geometry=self.as_point(), properties={
                 "time": self.timestamp,
@@ -104,6 +131,9 @@ class DeviceTrackingPoint(object):
                 "source": self.source,
             })
         except Exception:
+            LOG.debug(f'Device tracking as_point_feature exception {Exception}.')
+            log_metric('transmission.error', tags={'method': 'as_point_feature_exception'})
+
             raise InvalidTrackingPointError("Unable to build GeoJSON Point Feature from tracking data")
 
     @staticmethod
@@ -116,28 +146,46 @@ class DeviceTrackingPoint(object):
     @staticmethod
     def get_linestring_feature(tracking_points):
         try:
+            LOG.debug(f'Device tracking get_linestring_list with tracking points {tracking_points}.')
+            log_metric('transmission.info', tags={'method': 'get_linestring_list'})
+
             linestring, linestring_timestamps = DeviceTrackingPoint.get_linestring_list(tracking_points)
             return Feature(geometry=linestring, properties={"linestringTimestamps": linestring_timestamps})
 
         except Exception:
+            LOG.debug(f'Device tracking get_linestring_feature exception {Exception}.')
+            log_metric('transmission.error', tags={'method': 'get_linestring_feature'})
+
             raise InvalidTrackingPointError("Unable to build GeoJSON LineString Feature from tracking data")
 
     @staticmethod
     def __extract_date_fields(date):
+        LOG.debug(f'Device tracking __extract_date_fields with date {date}.')
+        log_metric('transmission.info', tags={'method': '__extract_date_fields'})
+
         day, month, year = int(date[:2]), int(date[2:4]), int("20" + date[4:6])
         return day, month, year
 
     @staticmethod
     def __extract_time_fields(time):
+        LOG.debug(f'Device tracking __extract_time_fields with time {time}.')
+        log_metric('transmission.info', tags={'method': '__extract_time_fields'})
+
         hour, minute, second = int(time[:2]), int(time[2:4]), int(time[4:6])
         return hour, minute, second
 
     @staticmethod
     def __build_timestamp(date, time):
+        LOG.debug(f'Device tracking __build_timestamp with date {date} and time {time}.')
+        log_metric('transmission.info', tags={'method': '__extract_time_fields'})
+
         try:
             day, month, year = DeviceTrackingPoint.__extract_date_fields(date)
             hour, minute, second = DeviceTrackingPoint.__extract_time_fields(time)
             return datetime(year, month, day, hour, minute, second)
 
         except Exception as exception:
+            LOG.debug(f'Device tracking __build_timestamp exception {Exception}.')
+            log_metric('transmission.error', tags={'method': '__build_timestamp_exception'})
+
             raise InvalidTrackingPointError(f"Error building timestamp from device tracking data: '{exception}'")

--- a/apps/shipments/geojson.py
+++ b/apps/shipments/geojson.py
@@ -73,10 +73,8 @@ class InvalidTrackingPointError(APIException):
     """
     Extend DRF APIException so these are automatically transformed via the exception handler
     """
-    LOG.debug(f'Invalid Tracking Point Error {APIException}.')
+    LOG.error(f'Invalid Tracking Point Error {APIException}.')
     log_metric('transmission.error', tags={'method': 'invalid_tracking_point_error'})
-
-    pass
 
 
 class DeviceTrackingPoint(object):
@@ -96,13 +94,13 @@ class DeviceTrackingPoint(object):
             self.source = point['source'] if 'source' in point else None
 
         except IndexError:
-            LOG.debug(f'Device tracking index Error {IndexError}.')
+            LOG.error(f'Device tracking index Error {IndexError}.')
             log_metric('transmission.error', tags={'method': 'device_tracking_index_error'})
 
             raise InvalidTrackingPointError(f"Invalid Coordinates format from device")
 
         except KeyError as key_error:
-            LOG.debug(f'Device tracking key Error {key_error}.')
+            LOG.error(f'Device tracking key Error {key_error}.')
             log_metric('transmission.error', tags={'method': 'device_tracking_key_error'})
 
             raise InvalidTrackingPointError(f"Missing field {key_error} in tracking data from device")
@@ -114,7 +112,7 @@ class DeviceTrackingPoint(object):
         try:
             return Point((self.lon, self.lat))
         except Exception:
-            LOG.debug(f'Device tracking as_point exception {Exception}.')
+            LOG.error(f'Device tracking as_point exception {Exception}.')
             log_metric('transmission.error', tags={'method': 'as_point_exception'})
 
             raise InvalidTrackingPointError("Unable to build GeoJSON Point from tracking data")
@@ -131,7 +129,7 @@ class DeviceTrackingPoint(object):
                 "source": self.source,
             })
         except Exception:
-            LOG.debug(f'Device tracking as_point_feature exception {Exception}.')
+            LOG.error(f'Device tracking as_point_feature exception {Exception}.')
             log_metric('transmission.error', tags={'method': 'as_point_feature_exception'})
 
             raise InvalidTrackingPointError("Unable to build GeoJSON Point Feature from tracking data")
@@ -153,7 +151,7 @@ class DeviceTrackingPoint(object):
             return Feature(geometry=linestring, properties={"linestringTimestamps": linestring_timestamps})
 
         except Exception:
-            LOG.debug(f'Device tracking get_linestring_feature exception {Exception}.')
+            LOG.error(f'Device tracking get_linestring_feature exception {Exception}.')
             log_metric('transmission.error', tags={'method': 'get_linestring_feature'})
 
             raise InvalidTrackingPointError("Unable to build GeoJSON LineString Feature from tracking data")
@@ -185,7 +183,7 @@ class DeviceTrackingPoint(object):
             return datetime(year, month, day, hour, minute, second)
 
         except Exception as exception:
-            LOG.debug(f'Device tracking __build_timestamp exception {Exception}.')
+            LOG.error(f'Device tracking __build_timestamp exception {Exception}.')
             log_metric('transmission.error', tags={'method': '__build_timestamp_exception'})
 
             raise InvalidTrackingPointError(f"Error building timestamp from device tracking data: '{exception}'")

--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -5,11 +5,10 @@ from django.db import models
 from django.core.validators import RegexValidator
 from django.contrib.postgres.fields import JSONField
 from django.contrib.contenttypes.fields import GenericRelation
-from influxdb_metrics.loader import log_metric
-
-
 from enumfields import Enum
 from enumfields import EnumField
+from influxdb_metrics.loader import log_metric
+
 
 from apps.utils import random_id
 from apps.jobs.models import JobListener, AsyncJob

--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -5,6 +5,8 @@ from django.db import models
 from django.core.validators import RegexValidator
 from django.contrib.postgres.fields import JSONField
 from django.contrib.contenttypes.fields import GenericRelation
+from influxdb_metrics.loader import log_metric
+
 
 from enumfields import Enum
 from enumfields import EnumField
@@ -196,6 +198,8 @@ class Shipment(models.Model):
                 listener=self)
         else:
             LOG.error(f'Shipment {self.id} tried to update_vault_hash before load_data.shipment_id was set!')
+            log_metric('transmission.error', tags={'method': 'shipment.update_vault_hash', 'code': 'call_too_early',
+                                                   'package': 'shipment.models'})
         return async_job
 
     # Defaults

--- a/apps/shipments/rpc.py
+++ b/apps/shipments/rpc.py
@@ -10,7 +10,7 @@ class ShipmentRPCClient(RPCClient):
     def create_vault(self, storage_credentials_id, shipper_wallet_id, carrier_wallet_id):
         LOG.debug(f'Creating vault with storage_credentials_id {storage_credentials_id},'
                   f'shipper_wallet_id {shipper_wallet_id}, and carrier_wallet_id {carrier_wallet_id}.')
-        log_metric('transmission.info', tags={'method': 'shipment.rpcclient.create_vault'})
+        log_metric('transmission.info', tags={'method': 'shipment_rpcclient.create_vault', 'package': 'shipment.rpc'})
 
         result = self.call('load.create_vault', {
             "storageCredentials": storage_credentials_id,
@@ -25,12 +25,15 @@ class ShipmentRPCClient(RPCClient):
                 return result['vault_id']
 
         LOG.error('Invalid creation of vault.')
+        log_metric('transmission.error', tags={'method': 'shipment_rpcclient.create_vault', 'package': 'shipment.rpc',
+                                               'code': 'RPCError'})
         raise RPCError("Invalid response from Engine")
 
     def add_shipment_data(self, storage_credentials_id, wallet_id, vault_id, shipment_data):
         LOG.debug(f'Adding shipment data with storage_credentials_id {storage_credentials_id},'
                   f'wallet_id {wallet_id}, and vault_id {vault_id}.')
-        log_metric('transmission.info', tags={'method': 'shipment.rpcclient.add_shipment_data'})
+        log_metric('transmission.info', tags={'method': 'shipment_rpcclient.add_shipment_data',
+                                              'package': 'shipment.rpc'})
 
         result = self.call('load.add_shipment_data', {
             "storageCredentials": storage_credentials_id,
@@ -43,6 +46,8 @@ class ShipmentRPCClient(RPCClient):
             LOG.debug('Successful addition of shipment data.')
             return result['vault_signed']
 
+        log_metric('transmission.error', tags={'method': 'shipment_rpcclient.add_shipment_data',
+                                               'package': 'shipment.rpc', 'code': 'RPCError'})
         LOG.error('Invalid addition of shipment data.')
         raise RPCError("Invalid response from Engine")
 
@@ -50,7 +55,8 @@ class ShipmentRPCClient(RPCClient):
                                     valid_until, funding_type, shipment_amount):
         LOG.debug(f'Creating shipment transaction with funding_type {funding_type}, shipment_amount {shipment_amount},'
                   f'shipper_wallet_id {shipper_wallet_id}, and carrier_wallet_id {carrier_wallet_id}.')
-        log_metric('transmission.info', tags={'method': 'shipment.rpcclient.create_shipment_transaction'})
+        log_metric('transmission.info', tags={'method': 'shipment_rpcclient.create_shipment_transaction',
+                                              'package': 'shipment.rpc'})
 
         result = self.call('load.create_shipment_transaction', {
             "shipperWallet": shipper_wallet_id,
@@ -65,13 +71,16 @@ class ShipmentRPCClient(RPCClient):
                 LOG.debug('Successful creation of shipment transaction.')
                 return result['contractVersion'], result['transaction']
 
+        log_metric('transmission.error', tags={'method': 'shipment_rpcclient.create_shipment_transaction',
+                                               'package': 'shipment.rpc', 'code': 'RPCError'})
         LOG.error('Invalid creation of shipment data.')
         raise RPCError("Invalid response from Engine")
 
     def get_tracking_data(self, storage_credentials_id, wallet_id, vault_id):
         LOG.debug(f'Retrieving of tracking data with storage_credentials_id {storage_credentials_id},'
                   f'wallet_id {wallet_id}, and vault_id {vault_id}.')
-        log_metric('transmission.info', tags={'method': 'shipment.rpcclient.get_tracking_data'})
+        log_metric('transmission.info', tags={'method': 'shipment_rpcclient.get_tracking_data',
+                                              'package': 'shipment.rpc'})
 
         result = self.call('load.get_tracking_data', {
             "storageCredentials": storage_credentials_id,
@@ -84,13 +93,16 @@ class ShipmentRPCClient(RPCClient):
                 LOG.debug('Successful retrieval of tracking data.')
                 return result['contents']
 
+        log_metric('transmission.error', tags={'method': 'shipment_rpcclient.get_tracking_data',
+                                               'package': 'shipment.rpc', 'code': 'RPCError'})
         LOG.error('Invalid retrieval of tracking data.')
         raise RPCError("Invalid response from Engine")
 
     def update_vault_hash_transaction(self, wallet_id, current_shipment_id, url, vault_hash):
         LOG.debug(f'Updating vault hash transaction with current_shipment_id {current_shipment_id},'
                   f'vault_hash {vault_hash}, and wallet_id {wallet_id}.')
-        log_metric('transmission.info', tags={'method': 'shipment.rpcclient.update_vault_hash_transaction'})
+        log_metric('transmission.info', tags={'method': 'shipment_rpcclient.update_vault_hash_transaction',
+                                               'package': 'shipment.rpc'})
 
         result = self.call('load.update_vault_hash_transaction', {
             "shipperWallet": wallet_id,
@@ -104,5 +116,7 @@ class ShipmentRPCClient(RPCClient):
                 LOG.debug('Successful update of vault hash transaction.')
                 return result['transaction']
 
+        log_metric('transmission.error', tags={'method': 'shipment_rpcclient.update_vault_hash_transaction',
+                                               'package': 'shipment.rpc', 'code': 'RPCError'})
         LOG.error('Invalid update of vault hash transaction.')
         raise RPCError("Invalid response from Engine")

--- a/apps/shipments/rpc.py
+++ b/apps/shipments/rpc.py
@@ -1,8 +1,16 @@
+import logging
+
 from apps.rpc_client import RPCClient, RPCError
+from influxdb_metrics.loader import log_metric
+
+LOG = logging.getLogger('transmission')
 
 
 class ShipmentRPCClient(RPCClient):
     def create_vault(self, storage_credentials_id, shipper_wallet_id, carrier_wallet_id):
+        LOG.debug(f'Creating vault with storage_credentials_id {storage_credentials_id},'
+                  f'shipper_wallet_id {shipper_wallet_id}, and carrier_wallet_id {carrier_wallet_id}.')
+        log_metric('transmission.info', tags={'method': 'has_object_permission'})
 
         result = self.call('load.create_vault', {
             "storageCredentials": storage_credentials_id,
@@ -12,10 +20,17 @@ class ShipmentRPCClient(RPCClient):
 
         if 'success' in result and result['success']:
             if 'vault_id' in result:
+                LOG.debug(f'Succesful creation of vault with id {result["vault_id"]}.')
+
                 return result['vault_id']
+
+        LOG.error('Invalid creation of vault.')
         raise RPCError("Invalid response from Engine")
 
     def add_shipment_data(self, storage_credentials_id, wallet_id, vault_id, shipment_data):
+        LOG.debug(f'Adding shipment data with storage_credentials_id {storage_credentials_id},'
+                  f'shipper_wallet_id {shipper_wallet_id}, and carrier_wallet_id {carrier_wallet_id}.')
+        log_metric('transmission.info', tags={'method': 'has_object_permission'})
 
         result = self.call('load.add_shipment_data', {
             "storageCredentials": storage_credentials_id,
@@ -25,11 +40,17 @@ class ShipmentRPCClient(RPCClient):
         })
 
         if 'success' in result and result['success']:
+            LOG.debug('Successful addition of shipment data.')
             return result['vault_signed']
+
+        LOG.error('Invalid addition of shipment data.')
         raise RPCError("Invalid response from Engine")
 
     def create_shipment_transaction(self, shipper_wallet_id, carrier_wallet_id,  # pylint: disable=too-many-arguments
                                     valid_until, funding_type, shipment_amount):
+        LOG.debug(f'Creating shipment transaction with funding_type {funding_type}, shipment_amount {shipment_amount},'
+                  f'shipper_wallet_id {shipper_wallet_id}, and carrier_wallet_id {carrier_wallet_id}.')
+        log_metric('transmission.info', tags={'method': 'has_object_permission'})
 
         result = self.call('load.create_shipment_transaction', {
             "shipperWallet": shipper_wallet_id,
@@ -41,11 +62,16 @@ class ShipmentRPCClient(RPCClient):
 
         if 'success' in result and result['success']:
             if 'transaction' in result and 'contractVersion' in result:
+                LOG.debug('Successful creation of shipment transaction.')
                 return result['contractVersion'], result['transaction']
 
+        LOG.error('Invalid creation of shipment data.')
         raise RPCError("Invalid response from Engine")
 
     def get_tracking_data(self, storage_credentials_id, wallet_id, vault_id):
+        LOG.debug(f'Retrieving of tracking data with storage_credentials_id {storage_credentials_id},'
+                  f'wallet_id {wallet_id}, and vault_id {vault_id}.')
+        log_metric('transmission.info', tags={'method': 'has_object_permission'})
 
         result = self.call('load.get_tracking_data', {
             "storageCredentials": storage_credentials_id,
@@ -55,11 +81,17 @@ class ShipmentRPCClient(RPCClient):
 
         if 'success' in result and result['success']:
             if 'contents' in result:
+                LOG.debug('Successful retrieval of tracking data.')
                 return result['contents']
 
+        LOG.error('Invalid retrieval of tracking data.')
         raise RPCError("Invalid response from Engine")
 
     def update_vault_hash_transaction(self, wallet_id, current_shipment_id, url, vault_hash):
+        LOG.debug(f'Updating vault hash transaction with current_shipment_id {current_shipment_id},'
+                  f'vault_hash {vault_hash}, and wallet_id {wallet_id}.')
+        log_metric('transmission.info', tags={'method': 'has_object_permission'})
+
         result = self.call('load.update_vault_hash_transaction', {
             "shipperWallet": wallet_id,
             "shipmentId": current_shipment_id,
@@ -69,6 +101,8 @@ class ShipmentRPCClient(RPCClient):
 
         if 'success' in result and result['success']:
             if 'transaction' in result:
+                LOG.debug('Successful update of vault hash transaction.')
                 return result['transaction']
 
+        LOG.error('Invalid update of vault hash transaction.')
         raise RPCError("Invalid response from Engine")

--- a/apps/shipments/rpc.py
+++ b/apps/shipments/rpc.py
@@ -102,7 +102,7 @@ class ShipmentRPCClient(RPCClient):
         LOG.debug(f'Updating vault hash transaction with current_shipment_id {current_shipment_id},'
                   f'vault_hash {vault_hash}, and wallet_id {wallet_id}.')
         log_metric('transmission.info', tags={'method': 'shipment_rpcclient.update_vault_hash_transaction',
-                                               'package': 'shipment.rpc'})
+                                              'package': 'shipment.rpc'})
 
         result = self.call('load.update_vault_hash_transaction', {
             "shipperWallet": wallet_id,

--- a/apps/shipments/rpc.py
+++ b/apps/shipments/rpc.py
@@ -29,7 +29,7 @@ class ShipmentRPCClient(RPCClient):
 
     def add_shipment_data(self, storage_credentials_id, wallet_id, vault_id, shipment_data):
         LOG.debug(f'Adding shipment data with storage_credentials_id {storage_credentials_id},'
-                  f'shipper_wallet_id {shipper_wallet_id}, and carrier_wallet_id {carrier_wallet_id}.')
+                  f'wallet_id {wallet_id}, and vault_id {vault_id}.')
         log_metric('transmission.info', tags={'method': 'has_object_permission'})
 
         result = self.call('load.add_shipment_data', {

--- a/apps/shipments/rpc.py
+++ b/apps/shipments/rpc.py
@@ -10,7 +10,7 @@ class ShipmentRPCClient(RPCClient):
     def create_vault(self, storage_credentials_id, shipper_wallet_id, carrier_wallet_id):
         LOG.debug(f'Creating vault with storage_credentials_id {storage_credentials_id},'
                   f'shipper_wallet_id {shipper_wallet_id}, and carrier_wallet_id {carrier_wallet_id}.')
-        log_metric('transmission.info', tags={'method': 'has_object_permission'})
+        log_metric('transmission.info', tags={'method': 'shipment.rpcclient.create_vault'})
 
         result = self.call('load.create_vault', {
             "storageCredentials": storage_credentials_id,
@@ -30,7 +30,7 @@ class ShipmentRPCClient(RPCClient):
     def add_shipment_data(self, storage_credentials_id, wallet_id, vault_id, shipment_data):
         LOG.debug(f'Adding shipment data with storage_credentials_id {storage_credentials_id},'
                   f'wallet_id {wallet_id}, and vault_id {vault_id}.')
-        log_metric('transmission.info', tags={'method': 'has_object_permission'})
+        log_metric('transmission.info', tags={'method': 'shipment.rpcclient.add_shipment_data'})
 
         result = self.call('load.add_shipment_data', {
             "storageCredentials": storage_credentials_id,
@@ -50,7 +50,7 @@ class ShipmentRPCClient(RPCClient):
                                     valid_until, funding_type, shipment_amount):
         LOG.debug(f'Creating shipment transaction with funding_type {funding_type}, shipment_amount {shipment_amount},'
                   f'shipper_wallet_id {shipper_wallet_id}, and carrier_wallet_id {carrier_wallet_id}.')
-        log_metric('transmission.info', tags={'method': 'has_object_permission'})
+        log_metric('transmission.info', tags={'method': 'shipment.rpcclient.create_shipment_transaction'})
 
         result = self.call('load.create_shipment_transaction', {
             "shipperWallet": shipper_wallet_id,
@@ -71,7 +71,7 @@ class ShipmentRPCClient(RPCClient):
     def get_tracking_data(self, storage_credentials_id, wallet_id, vault_id):
         LOG.debug(f'Retrieving of tracking data with storage_credentials_id {storage_credentials_id},'
                   f'wallet_id {wallet_id}, and vault_id {vault_id}.')
-        log_metric('transmission.info', tags={'method': 'has_object_permission'})
+        log_metric('transmission.info', tags={'method': 'shipment.rpcclient.get_tracking_data'})
 
         result = self.call('load.get_tracking_data', {
             "storageCredentials": storage_credentials_id,
@@ -90,7 +90,7 @@ class ShipmentRPCClient(RPCClient):
     def update_vault_hash_transaction(self, wallet_id, current_shipment_id, url, vault_hash):
         LOG.debug(f'Updating vault hash transaction with current_shipment_id {current_shipment_id},'
                   f'vault_hash {vault_hash}, and wallet_id {wallet_id}.')
-        log_metric('transmission.info', tags={'method': 'has_object_permission'})
+        log_metric('transmission.info', tags={'method': 'shipment.rpcclient.update_vault_hash_transaction'})
 
         result = self.call('load.update_vault_hash_transaction', {
             "shipperWallet": wallet_id,

--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -2,7 +2,6 @@ import logging
 
 from django.dispatch import receiver
 from django.db.models.signals import post_save
-from influxdb_metrics.loader import log_metric
 
 from apps.eth.signals import event_update
 from apps.eth.models import TransactionReceipt

--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -18,8 +18,8 @@ LOG = logging.getLogger('transmission')
 
 @receiver(job_update, sender=Shipment, dispatch_uid='shipment_job_update')
 def shipment_job_update(sender, message, listener, **kwargs):
-    LOG.debug(f'Shipment job update with sender {sender}.')
-    log_metric('transmission.info', tags={'method': 'shipment_job_update'})
+    LOG.debug(f'Shipment job update with message {message.id}.')
+    log_metric('transmission.info', tags={'method': 'shipment.shipment_job_update'})
 
     if message.type == MessageType.ETH_TRANSACTION:
         LOG.debug(f'Message type is {message.type}.')
@@ -32,8 +32,8 @@ def shipment_job_update(sender, message, listener, **kwargs):
 
 @receiver(event_update, sender=Shipment, dispatch_uid='shipment_event_update')
 def shipment_event_update(sender, event, listener, **kwargs):
-    LOG.debug(f'Shipment event update with sender {sender}.')
-    log_metric('transmission.info', tags={'method': 'shipment_event_update'})
+    LOG.debug(f'Shipment event update with listener {listener.id}.')
+    log_metric('transmission.info', tags={'method': 'shipment.shipment_event_update'})
 
     if event.event_name == "CreateNewShipmentEvent":
         LOG.debug(f'Event.event_name is CreateNewShipmentEvent.')
@@ -55,8 +55,8 @@ def shipment_event_update(sender, event, listener, **kwargs):
 @receiver(post_save, sender=Shipment, dispatch_uid='shipment_post_save')
 def shipment_post_save(sender, **kwargs):
     instance, created = kwargs["instance"], kwargs["created"]
-    LOG.debug(f'Shipment post save with sender {sender}.')
-    log_metric('transmission.info', tags={'method': 'shipment_post_save'})
+    LOG.debug(f'Shipment post save with shipment {instance.id}.')
+    log_metric('transmission.info', tags={'method': 'shipment.shipment_post_save'})
 
     if created:
         # Create vault
@@ -90,7 +90,7 @@ def shipment_post_save(sender, **kwargs):
 def loadshipment_post_save(sender, **kwargs):
     instance, created = kwargs["instance"], kwargs["created"]
     LOG.debug(f'LoadShipment post save with sender {sender}.')
-    log_metric('transmission.info', tags={'method': 'loadshipment_post_save'})
+    log_metric('transmission.info', tags={'method': 'loadshipment.loadshipment_post_save'})
     if created:
         LOG.debug(f'Creating a shipment on the load contract.')
         # Create shipment on the LOAD contract

--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -85,7 +85,7 @@ def shipment_post_save(sender, **kwargs):
 @receiver(post_save, sender=LoadShipment, dispatch_uid='loadshipment_post_save')
 def loadshipment_post_save(sender, **kwargs):
     instance, created = kwargs["instance"], kwargs["created"]
-    LOG.debug(f'LoadShipment post save with sender {sender}.')
+    LOG.debug(f'LoadShipment post save for LoadShipment: {instance.id}')
     if created:
         LOG.debug(f'Creating a shipment on the load contract.')
         # Create shipment on the LOAD contract

--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -1,5 +1,8 @@
+import logging
+
 from django.dispatch import receiver
 from django.db.models.signals import post_save
+from influxdb_metrics.loader import log_metric
 
 from apps.eth.signals import event_update
 from apps.eth.models import TransactionReceipt
@@ -10,9 +13,16 @@ from .rpc import ShipmentRPCClient
 from .serializers import ShipmentVaultSerializer
 
 
+LOG = logging.getLogger('transmission')
+
+
 @receiver(job_update, sender=Shipment, dispatch_uid='shipment_job_update')
 def shipment_job_update(sender, message, listener, **kwargs):
+    LOG.debug(f'Shipment job update with sender {sender}.')
+    log_metric('transmission.info', tags={'method': 'shipment_job_update'})
+
     if message.type == MessageType.ETH_TRANSACTION:
+        LOG.debug(f'Message type is {message.type}.')
         TransactionReceipt.objects.filter(eth_action_id=message.body['transactionHash']
                                           ).update(**TransactionReceipt.convert_receipt(message.body))
 
@@ -22,10 +32,11 @@ def shipment_job_update(sender, message, listener, **kwargs):
 
 @receiver(event_update, sender=Shipment, dispatch_uid='shipment_event_update')
 def shipment_event_update(sender, event, listener, **kwargs):
-
-    # TODO: Metrics for processed Events
+    LOG.debug(f'Shipment event update with sender {sender}.')
+    log_metric('transmission.info', tags={'method': 'shipment_event_update'})
 
     if event.event_name == "CreateNewShipmentEvent":
+        LOG.debug(f'Event.event_name is CreateNewShipmentEvent.')
         listener.load_data.shipment_id = event.return_values['shipmentID']
         listener.load_data.start_block = event.block_number
         listener.load_data.shipment_created = True
@@ -37,19 +48,23 @@ def shipment_event_update(sender, event, listener, **kwargs):
                                                  listener.vault_id, ShipmentVaultSerializer(listener).data)
 
         # Update LOAD contract with vault uri/hash
+        LOG.debug(f'Updating load contract with hash {signature["hash"]}.')
         listener.update_vault_hash(signature['hash'])
 
 
 @receiver(post_save, sender=Shipment, dispatch_uid='shipment_post_save')
 def shipment_post_save(sender, **kwargs):
     instance, created = kwargs["instance"], kwargs["created"]
+    LOG.debug(f'Shipment post save with sender {sender}.')
+    log_metric('transmission.info', tags={'method': 'shipment_post_save'})
+
     if created:
         # Create vault
         rpc_client = ShipmentRPCClient()
         instance.vault_id = rpc_client.create_vault(instance.storage_credentials_id, instance.shipper_wallet_id,
                                                     instance.carrier_wallet_id)
-
         instance.save()
+        LOG.debug(f'Creating vault with vault_id {instance.vault_id}.')
 
         # Create LoadShipment entity
         # TODO: Get FundingType,ShipmentAmount,ValidUntil for use in LOAD Contract/LoadShipment
@@ -66,6 +81,7 @@ def shipment_post_save(sender, **kwargs):
         signature = rpc_client.add_shipment_data(instance.storage_credentials_id, instance.shipper_wallet_id,
                                                  instance.vault_id, ShipmentVaultSerializer(instance).data)
 
+        LOG.debug(f'Updating LOAD contract with vault uri/hash {signature["hash"]}.')
         # Update LOAD contract with vault uri/hash
         instance.update_vault_hash(signature['hash'])
 
@@ -73,7 +89,10 @@ def shipment_post_save(sender, **kwargs):
 @receiver(post_save, sender=LoadShipment, dispatch_uid='loadshipment_post_save')
 def loadshipment_post_save(sender, **kwargs):
     instance, created = kwargs["instance"], kwargs["created"]
+    LOG.debug(f'LoadShipment post save with sender {sender}.')
+    log_metric('transmission.info', tags={'method': 'loadshipment_post_save'})
     if created:
+        LOG.debug(f'Creating a shipment on the load contract.')
         # Create shipment on the LOAD contract
         AsyncJob.rpc_job_for_listener(
             rpc_class=ShipmentRPCClient,

--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -19,7 +19,6 @@ LOG = logging.getLogger('transmission')
 @receiver(job_update, sender=Shipment, dispatch_uid='shipment_job_update')
 def shipment_job_update(sender, message, listener, **kwargs):
     LOG.debug(f'Shipment job update with message {message.id}.')
-    log_metric('transmission.info', tags={'method': 'shipment.shipment_job_update'})
 
     if message.type == MessageType.ETH_TRANSACTION:
         LOG.debug(f'Message type is {message.type}.')
@@ -33,7 +32,6 @@ def shipment_job_update(sender, message, listener, **kwargs):
 @receiver(event_update, sender=Shipment, dispatch_uid='shipment_event_update')
 def shipment_event_update(sender, event, listener, **kwargs):
     LOG.debug(f'Shipment event update with listener {listener.id}.')
-    log_metric('transmission.info', tags={'method': 'shipment.shipment_event_update'})
 
     if event.event_name == "CreateNewShipmentEvent":
         LOG.debug(f'Event.event_name is CreateNewShipmentEvent.')
@@ -56,7 +54,6 @@ def shipment_event_update(sender, event, listener, **kwargs):
 def shipment_post_save(sender, **kwargs):
     instance, created = kwargs["instance"], kwargs["created"]
     LOG.debug(f'Shipment post save with shipment {instance.id}.')
-    log_metric('transmission.info', tags={'method': 'shipment.shipment_post_save'})
 
     if created:
         # Create vault
@@ -90,7 +87,6 @@ def shipment_post_save(sender, **kwargs):
 def loadshipment_post_save(sender, **kwargs):
     instance, created = kwargs["instance"], kwargs["created"]
     LOG.debug(f'LoadShipment post save with sender {sender}.')
-    log_metric('transmission.info', tags={'method': 'loadshipment.loadshipment_post_save'})
     if created:
         LOG.debug(f'Creating a shipment on the load contract.')
         # Create shipment on the LOAD contract

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -98,7 +98,7 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         """
         partial = kwargs.pop('partial', False)
         instance = self.get_object()
-        LOG.debug(f'Updating shipment {pk} with new details.')
+        LOG.debug(f'Updating shipment {instance} with new details.')
         log_metric('transmission.info', tags={'method': 'shipments.tracking'})
 
         serializer = ShipmentUpdateSerializer(instance, data=request.data, partial=partial)

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -43,7 +43,7 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         Create a Shipment object and make Async Request to Engine
         """
         LOG.debug(f'Creating a shipment object.')
-        log_metric('transmission.info', tags={'method': 'shipments.create'})
+        log_metric('transmission.info', tags={'method': 'shipments.create', 'package': 'shipments.views'})
         # Create Shipment
         serializer = ShipmentCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -64,7 +64,7 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         Retrieve tracking data for this Shipment after checking permissions with Profiles
         """
         LOG.debug(f'Retrieve tracking data for a shipment {pk}.')
-        log_metric('transmission.info', tags={'method': 'shipments.tracking'})
+        log_metric('transmission.info', tags={'method': 'shipments.tracking', 'package': 'shipments.views'})
         shipment = Shipment.objects.get(pk=pk)
 
         # TODO: re-implement device/shipment authorization for tracking data
@@ -96,7 +96,7 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         partial = kwargs.pop('partial', False)
         instance = self.get_object()
         LOG.debug(f'Updating shipment {instance} with new details.')
-        log_metric('transmission.info', tags={'method': 'shipments.update'})
+        log_metric('transmission.info', tags={'method': 'shipments.update', 'package': 'shipments.views'})
 
         serializer = ShipmentUpdateSerializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
@@ -141,7 +141,7 @@ class LocationViewSet(viewsets.ModelViewSet):
         serializer = LocationSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         LOG.debug(f'Creating a location object.')
-        log_metric('transmission.info', tags={'method': 'location.create'})
+        log_metric('transmission.info', tags={'method': 'location.create', 'package': 'shipments.views'})
 
         location = self.perform_create(serializer)
 

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -76,17 +76,14 @@ class ShipmentViewSet(viewsets.ModelViewSet):
 
         if 'as_line' in request.query_params:
             all_features = build_line_string_feature(shipment, tracking_data)
-            LOG.debug(f'Returning features as_line with features {all_features}.')
 
         elif 'as_point' in request.query_params:
             all_features = build_point_features(shipment, tracking_data)
-            LOG.debug(f'Returning features as_point with features {all_features}.')
 
         else:
             all_features = []
             all_features += build_line_string_feature(shipment, tracking_data)
             all_features += build_point_features(shipment, tracking_data)
-            LOG.debug(f'Returning features {all_features}.')
 
         feature_collection = build_feature_collection(all_features)
 
@@ -99,7 +96,7 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         partial = kwargs.pop('partial', False)
         instance = self.get_object()
         LOG.debug(f'Updating shipment {instance} with new details.')
-        log_metric('transmission.info', tags={'method': 'shipments.tracking'})
+        log_metric('transmission.info', tags={'method': 'shipments.update'})
 
         serializer = ShipmentUpdateSerializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
@@ -107,7 +104,7 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         shipment = self.perform_update(serializer)
         async_job = shipment.asyncjob_set.latest('created_at')
         response = ShipmentTxSerializer(shipment)
-        LOG.debug(f'Async_job created with id {async_job.id}.')
+        LOG.debug(f'Asyncjob created with id {async_job.id}.')
         if async_job:
             response.instance.async_job_id = async_job.id
 


### PR DESCRIPTION
Transmission needs to support reporting application metrics to an InfluxDB instance. This provides the ability to track and analyze usage data to find the most used methods, alert when exceeding error thresholds, and identify potential areas for enhancing performance. Grafana is a useful tool for building charts and graphs for displaying this information.

To enable metric reporting to InfluxDB, set the following environment variable:

INFLUXDB_URL - With the format http://{host}:{port}/{database}
