### PR TITLE
Change the vault hash rate limit to occur half as often.

### DIFF
--- a/conf/apps.py
+++ b/conf/apps.py
@@ -8,4 +8,4 @@ CELERY_WALLET_RETRY = 30
 CELERY_TXHASH_RETRY = 30
 
 # Time in minutes to be used when rate limiting vault hash updates
-VAULT_HASH_RATE_LIMIT = 60 if ENVIRONMENT == 'PROD' else 5
+VAULT_HASH_RATE_LIMIT = 120 if ENVIRONMENT == 'PROD' else 5


### PR DESCRIPTION
Change the vault hash rate limit to occur half as often to limit costs.