### PR TITLE
Clarified the response when creating a related object without the req…

### DIFF
--- a/apps/exceptions.py
+++ b/apps/exceptions.py
@@ -107,6 +107,14 @@ def exception_handler(exc, context):
     if not response:
         return unhandled_drf_exception_handler(exc, context)
 
+    if response.status_code == status.HTTP_400_BAD_REQUEST:
+        for field, detail in list(exc.detail.items()):
+            if isinstance(detail, dict):
+                keys = detail.keys()
+                for x in keys:
+                    exc.detail[f'{field}.{x}'] = detail[x]
+                exc.detail.pop(field)
+
     # Use regular DRF format if not rendered by DRF JSON API and not uniform
     is_json_api_view = rendered_with_json_api(context['view'])
     is_uniform = getattr(settings, 'JSON_API_UNIFORM_EXCEPTIONS', False)

--- a/apps/exceptions.py
+++ b/apps/exceptions.py
@@ -111,8 +111,8 @@ def exception_handler(exc, context):
         for field, detail in list(exc.detail.items()):
             if isinstance(detail, dict):
                 keys = detail.keys()
-                for x in keys:
-                    exc.detail[f'{field}.{x}'] = detail[x]
+                for key in keys:
+                    exc.detail[f'{field}.{key}'] = detail[key]
                 exc.detail.pop(field)
 
     # Use regular DRF format if not rendered by DRF JSON API and not uniform

--- a/apps/exceptions.py
+++ b/apps/exceptions.py
@@ -110,8 +110,7 @@ def exception_handler(exc, context):
     if response.status_code == status.HTTP_400_BAD_REQUEST:
         for field, detail in list(exc.detail.items()):
             if isinstance(detail, dict):
-                keys = detail.keys()
-                for key in keys:
+                for key in detail.keys():
                     exc.detail[f'{field}.{key}'] = detail[key]
                 exc.detail.pop(field)
 


### PR DESCRIPTION
…uired fields.

Previously, when creating shipment objects, if you included the shipment_from_location.{attr} without the necessary field of name, the response was not in the standardized json format. This change allows for more consistency and better understanding of where exactly the error occurred.