### PR TITLE
Remove the html responses when 404 is thrown

### DIFF
--- a/apps/exceptions.py
+++ b/apps/exceptions.py
@@ -147,3 +147,16 @@ def bad_request(request, exception, *args, **kwargs):
         }]
     }
     return JsonResponse(data, status=status.HTTP_400_BAD_REQUEST)
+
+
+def invalid_url(request, exception, *args, **kwargs):
+    """
+    Generic 404 error handler.
+    """
+    data = {
+        "errors": [{
+            "detail": "Error 404, page not foud",
+            "status": "404"
+        }]
+    }
+    return JsonResponse(data, status=status.HTTP_404_NOT_FOUND)

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -42,3 +42,8 @@ urlpatterns = [
 urlpatterns += router.urls
 
 urlpatterns = format_suffix_patterns(urlpatterns)
+
+# Fallback to Generic API responses instead of Django's built-in rendered HTML responses
+handler500 = 'apps.exceptions.server_error'
+handler400 = 'apps.exceptions.bad_request'
+handler404 = 'apps.exceptions.invalid_url'


### PR DESCRIPTION
When a 404 error was previously thrown, it would return an HTML response. This was inconsistent with other responses, so instead this change causes it to return a standard JSON error response