### PR TITLE
Enable SSL, mutual certificate authentication, protected views

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,12 @@ RUN echo "AllowAgentForwarding yes" >> /etc/ssh/sshd_config
 RUN echo "PasswordAuthentication no" >> /etc/ssh/sshd_config
 # ------------------------- #
 
-RUN apt-get update -y && apt-get -y install binutils libproj-dev gdal-bin rsync
+RUN apt-get update -y && apt-get -y install binutils libproj-dev gdal-bin rsync jq
+
+# Virtualenv for awscli #
+RUN pip install virtualenv
+RUN virtualenv /opt/aws
+RUN . /opt/aws/bin/activate && pip install --upgrade awscli
 
 COPY ./compose/django/requirements.txt /build/
 COPY ./compose/django/pip.cache /build/pip.cache

--- a/apps/authentication.py
+++ b/apps/authentication.py
@@ -1,0 +1,61 @@
+"""
+Copyright 2018 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from collections import namedtuple
+from django.conf import settings
+from rest_framework import exceptions
+from rest_framework.permissions import BasePermission
+from rest_framework_jwt.settings import api_settings
+from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+
+
+class AuthenticatedUser:
+    def __init__(self, payload):
+        self.id = payload.get('user_id')  # pylint:disable=invalid-name
+        self.username = payload.get('username')
+        self.email = payload.get('email')
+
+    def is_authenticated(self):
+        return True
+
+    def is_staff(self):
+        return False
+
+    def is_superuser(self):
+        return False
+
+
+class PassiveJSONWebTokenAuthentication(JSONWebTokenAuthentication):
+    def authenticate_credentials(self, payload):
+        if 'sub' not in payload:
+            raise exceptions.AuthenticationFailed('Invalid payload.')
+
+        payload['pk'] = payload['sub']
+        payload = namedtuple("User", payload.keys())(*payload.values())
+        payload = api_settings.JWT_PAYLOAD_HANDLER(payload)
+
+        user = AuthenticatedUser(payload)
+
+        return user
+
+
+class EngineRequest(BasePermission):
+    def has_permission(self, request, view):
+        if settings.ENV == 'LOCAL':
+            return True
+        elif 'X_NGINX_SOURCE' in request.META and request.META['X_NGINX_SOURCE'] == 'engine':
+            return True
+        return False

--- a/apps/authentication.py
+++ b/apps/authentication.py
@@ -54,7 +54,7 @@ class PassiveJSONWebTokenAuthentication(JSONWebTokenAuthentication):
 
 class EngineRequest(BasePermission):
     def has_permission(self, request, view):
-        if settings.ENV == 'LOCAL':
+        if settings.ENVIRONMENT in ('LOCAL', 'TEST'):
             return True
         elif 'X_NGINX_SOURCE' in request.META and request.META['X_NGINX_SOURCE'] == 'engine':
             return True

--- a/apps/authentication.py
+++ b/apps/authentication.py
@@ -56,6 +56,6 @@ class EngineRequest(BasePermission):
     def has_permission(self, request, view):
         if settings.ENVIRONMENT in ('LOCAL',):
             return True
-        elif 'X_NGINX_SOURCE' in request.META and request.META['X_NGINX_SOURCE'] == 'engine':
+        elif 'X_NGINX_SOURCE' in request.META and request.META['X_NGINX_SOURCE'] == 'internal':
             return True
         return False

--- a/apps/authentication.py
+++ b/apps/authentication.py
@@ -54,7 +54,7 @@ class PassiveJSONWebTokenAuthentication(JSONWebTokenAuthentication):
 
 class EngineRequest(BasePermission):
     def has_permission(self, request, view):
-        if settings.ENVIRONMENT in ('LOCAL', 'TEST'):
+        if settings.ENVIRONMENT in ('LOCAL',):
             return True
         elif 'X_NGINX_SOURCE' in request.META and request.META['X_NGINX_SOURCE'] == 'engine':
             return True

--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework_json_api import renderers as jsapi_renderers
 from influxdb_metrics.loader import log_metric
 
+from apps.authentication import EngineRequest
 from apps.eth.models import EthAction, Event
 from apps.eth.serializers import EventSerializer, EthActionSerializer
 
@@ -24,8 +25,7 @@ class EventViewSet(mixins.CreateModelMixin,
     serializer_class = EventSerializer
     parser_classes = (parsers.JSONParser,)
     renderer_classes = (renderers.JSONRenderer, jsapi_renderers.JSONRenderer)
-    # TODO: Restrict for Engine
-    permission_classes = (permissions.AllowAny,)
+    permission_classes = (EngineRequest,)
 
     def create(self, request, *args, **kwargs):
         log_metric('transmission.info', tags={'method': 'events.create', 'module': __name__})

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -1,14 +1,14 @@
 import logging
 
-from rest_framework import viewsets, mixins, parsers, permissions, status, renderers
+from rest_framework import viewsets, mixins, parsers, status, renderers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework_json_api import parsers as jsapi_parsers
 from influxdb_metrics.loader import log_metric
 
+from apps.authentication import EngineRequest
 from .models import AsyncJob
 from .serializers import AsyncJobSerializer, MessageSerializer
-
 
 LOG = logging.getLogger('transmission')
 
@@ -24,7 +24,7 @@ class JobsViewSet(mixins.ListModelMixin,
     parser_classes = (parsers.JSONParser, jsapi_parsers.JSONParser)
 
     @action(detail=True, methods=['post'],
-            permission_classes=[permissions.AllowAny],
+            permission_classes=[EngineRequest],
             renderer_classes=[renderers.JSONRenderer])
     def message(self, request, version, pk):
         LOG.debug(f'Jobs message called.')

--- a/apps/rpc_client.py
+++ b/apps/rpc_client.py
@@ -31,7 +31,7 @@ class RPCClient(object):
         self.url = settings.ENGINE_RPC_URL
         self.payload = {"jsonrpc": "2.0", "id": 0, "params": {}}
         self.session = requests.session()
-        if settings.ENVIRONMENT in ('PROD', 'STAGE', 'DEV'):
+        if settings.ENVIRONMENT in ('PROD', 'STAGE', 'DEV', 'DEMO'):
             self.session.cert = ('/app/client-cert.crt', '/app/client-cert.key')
             self.session.verify = '/app/ca-bundle.crt'
         self.session.headers = {'content-type': 'application/json'}

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -1,9 +1,5 @@
 import json
 import decimal
-from collections import namedtuple
-from rest_framework import exceptions
-from rest_framework_jwt.settings import api_settings
-from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 from drf_enum_field.fields import EnumField
 
 
@@ -53,37 +49,6 @@ def assertDeepAlmostEqual(test_case, expected, actual, *args, **kwargs):  # nope
 class EnumToNameField(EnumField):
     def to_internal_value(self, data):
         return super(EnumToNameField, self).to_internal_value(data).name
-
-
-class AuthenticatedUser:
-    def __init__(self, payload):
-        self.id = payload.get('user_id')  # pylint:disable=invalid-name
-        self.username = payload.get('username')
-        self.email = payload.get('email')
-
-    def is_authenticated(self):
-        return True
-
-    def is_staff(self):
-        return False
-
-    def is_superuser(self):
-        return False
-
-
-class PassiveJSONWebTokenAuthentication(JSONWebTokenAuthentication):
-
-    def authenticate_credentials(self, payload):
-        if 'sub' not in payload:
-            raise exceptions.AuthenticationFailed('Invalid payload.')
-
-        payload['pk'] = payload['sub']
-        payload = namedtuple("User", payload.keys())(*payload.values())
-        payload = api_settings.JWT_PAYLOAD_HANDLER(payload)
-
-        user = AuthenticatedUser(payload)
-
-        return user
 
 
 def snake_to_sentence(word):

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -1,5 +1,7 @@
-import json
 import decimal
+import json
+import re
+
 from drf_enum_field.fields import EnumField
 
 
@@ -61,6 +63,13 @@ def build_auth_headers_from_request(request):
 
     token = request.auth.decode('utf-8')
     return {'Authorization': f"JWT {token}"}
+
+
+DN_REGEX = re.compile(r'(?:/?)(.+?)(?:=)([^/]+)')
+
+
+def parse_dn(ssl_dn):
+    return dict(DN_REGEX.findall(ssl_dn))
 
 
 class DecimalEncoder(json.JSONEncoder):

--- a/compose/django/download-certs.sh
+++ b/compose/django/download-certs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+echo "Downloading certificates from ACM"
+
+SUBDOMAIN=$APP.${ENV,,}-internal
+
+echo "Looking for existing certificate in ACM"
+CERT_ARN=$(aws acm list-certificates | jq -r "[.CertificateSummaryList[] | select(.DomainName == \"$SUBDOMAIN\")][0].CertificateArn")
+
+# Create private certificate in AWS ACM
+if [ $CERT_ARN = "null" ];
+then
+  echo "Creating new certificate"
+  CERT_ARN=$(aws --region us-east-1 acm request-certificate \
+  --domain-name $SUBDOMAIN \
+  --idempotency-token $APP$ENV \
+  --options CertificateTransparencyLoggingPreference=DISABLED \
+  --certificate-authority-arn $CERT_AUTHORITY_ARN | jq -r '.CertificateArn')
+
+  echo "Waiting for certificate to be ready"
+  STATUS=$(aws acm describe-certificate --certificate-arn $CERT_ARN | jq -r '.Certificate.Status')
+  while [ $STATUS != "ISSUED" ] && [ $STATUS != "FAILED" ]
+  do
+    sleep 2
+    STATUS=$(aws acm describe-certificate --certificate-arn $CERT_ARN | jq -r '.Certificate.Status')
+  done
+
+  echo "Tagging certificate"
+  aws acm add-tags-to-certificate --certificate-arn $CERT_ARN --tags Key=Name,Value=$SUBDOMAIN
+fi
+
+# Export certificate as JSON
+echo "Exporting certificate"
+CERT_PASS=$(openssl rand --base64 12)
+CERT_JSON=$(aws --region us-east-1 acm export-certificate --certificate-arn $CERT_ARN --passphrase $CERT_PASS)
+CA_CERT_JSON=$(aws --region us-east-1 acm-pca get-certificate-authority-certificate --certificate-authority-arn $CERT_AUTHORITY_ARN)
+
+# Copy certificate to nodejs
+echo "Copying certificate to nodejs"
+echo $CERT_JSON | jq -r '.Certificate' >> /app/client-cert.crt
+echo $CERT_JSON | jq -r '.CertificateChain' >> /app/client-cert.crt
+echo $CERT_JSON | jq -r '.PrivateKey' > /app/client-cert.encrypted.key
+echo $CA_CERT_JSON | jq -r '.Certificate' >> /app/ca-bundle.crt
+echo $CA_CERT_JSON | jq -r '.CertificateChain' >> /app/ca-bundle.crt
+
+# Decrypt key
+openssl rsa -passin pass:$CERT_PASS -in /app/client-cert.encrypted.key -out /app/client-cert.key
+chmod 644 /app/client-cert.key  # Change permission level so Django can read it

--- a/compose/django/entrypoint.sh
+++ b/compose/django/entrypoint.sh
@@ -1,8 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$ENV" = "PROD" ] || [ "$ENV" = "DEMO" ] || [ "$ENV" = "STAGE" ] || [ "$ENV" = "DEV" ];
 then
     echo "Not running in a docker-compose environment, skipping wait-for-it"
+
+    echo "Loading AWS CLI virtualenv"
+    source /opt/aws/bin/activate
+
+    /download-certs.sh
+
+    echo "Deactivating AWS CLI virtualenv"
+    deactivate
 else
     echo "Copying pip cache to volume"
     rsync -rc --chmod 777 /build/pip.cache/ /build/pip.volume

--- a/compose/django/ssh-entrypoint.sh
+++ b/compose/django/ssh-entrypoint.sh
@@ -2,12 +2,23 @@
 
 # Copy ECS env vars into bash profile so they're available to SSH'd users
 echo "export ENV=$ENV" >> /etc/profile
+echo "export CERT_AUTHORITY_ARN=$CERT_AUTHORITY_ARN" >> /etc/profile
 echo "export OIDC_RP_CLIENT_ID=$OIDC_RP_CLIENT_ID" >> /etc/profile
 echo "export OIDC_PUBLIC_KEY_PEM_BASE64=$OIDC_PUBLIC_KEY_PEM_BASE64" >> /etc/profile
 echo "export SERVICE=$SERVICE" >> /etc/profile
 echo "export REDIS_URL=$REDIS_URL" >> /etc/profile
+echo "export ENGINE_RPC_URL=$ENGINE_RPC_URL" >> /etc/profile
+echo "export INTERNAL_URL=$INTERNAL_URL" >> /etc/profile
 echo "export AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" >> /etc/profile
 sed -i -e "2iexport AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI\\" /usr/sbin/keymaker-get-public-keys
 sed -i -e "2iexport AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI\\" /usr/local/bin/keymaker-create-account-for-iam-user
+
+echo "Loading AWS CLI virtualenv"
+source /opt/aws/bin/activate
+
+/download-certs.sh
+
+echo "Deactivating AWS CLI virtualenv"
+deactivate
 
 exec "$@"

--- a/compose/nginx/entrypoint.sh
+++ b/compose/nginx/entrypoint.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-SUBDOMAIN=$APP-${ENV,,}
+SUBDOMAIN=$APP.${ENV,,}-internal
 
 echo "Looking for existing certificate in ACM"
-CERT_ARN=$(aws acm list-certificates | jq -r "[.CertificateSummaryList[] | select(.DomainName == \"$SUBDOMAIN.internal\")][0].CertificateArn")
+CERT_ARN=$(aws acm list-certificates | jq -r "[.CertificateSummaryList[] | select(.DomainName == \"$SUBDOMAIN\")][0].CertificateArn")
 
 # Create private certificate in AWS ACM
 if [ $CERT_ARN = "null" ];
 then
     echo "Creating new certificate"
     CERT_ARN=$(aws --region us-east-1 acm request-certificate \
-    --domain-name $SUBDOMAIN.internal \
+    --domain-name $SUBDOMAIN \
     --idempotency-token $APP$ENV \
     --options CertificateTransparencyLoggingPreference=DISABLED \
     --certificate-authority-arn $CERT_AUTHORITY_ARN | jq -r '.CertificateArn')
@@ -31,16 +31,20 @@ fi
 echo "Exporting certificate"
 CERT_PASS=$(openssl rand --base64 12)
 CERT_JSON=$(aws --region us-east-1 acm export-certificate --certificate-arn $CERT_ARN --passphrase $CERT_PASS)
+CA_CERT_JSON=$(aws --region us-east-1 acm-pca get-certificate-authority-certificate --certificate-authority-arn $CERT_AUTHORITY_ARN)
 
 # Copy certificate to nginx
 echo "Copying certificate to nginx"
-echo $CERT_JSON | jq -r '.Certificate' > /etc/nginx/certs/$SUBDOMAIN.internal.crt
-echo $CERT_JSON | jq -r '.PrivateKey' > /etc/nginx/certs/$SUBDOMAIN.internal.encrypted.key
+echo $CERT_JSON | jq -r '.Certificate' >> /etc/nginx/certs/$SUBDOMAIN.crt
+echo $CERT_JSON | jq -r '.CertificateChain' >> /etc/nginx/certs/$SUBDOMAIN.crt
+echo $CERT_JSON | jq -r '.PrivateKey' > /etc/nginx/certs/$SUBDOMAIN.encrypted.key
+echo $CA_CERT_JSON | jq -r '.Certificate' >> /etc/nginx/certs/ca-bundle.crt
+echo $CA_CERT_JSON | jq -r '.CertificateChain' >> /etc/nginx/certs/ca-bundle.crt
 
 # Decrypt key
-openssl rsa -passin pass:$CERT_PASS -in /etc/nginx/certs/$SUBDOMAIN.internal.encrypted.key -out /etc/nginx/certs/$SUBDOMAIN.internal.key
+openssl rsa -passin pass:$CERT_PASS -in /etc/nginx/certs/$SUBDOMAIN.encrypted.key -out /etc/nginx/certs/$SUBDOMAIN.key
 
 # Update nginx.conf with app name and environment
-sed -i "s/#{DOMAIN}/$SUBDOMAIN.internal/g" /etc/nginx/conf.d/default.conf
+sed -i "s/#{DOMAIN}/$SUBDOMAIN/g" /etc/nginx/conf.d/default.conf
 
 exec "$@"

--- a/compose/nginx/nginx.conf
+++ b/compose/nginx/nginx.conf
@@ -39,5 +39,7 @@ server {
         include /etc/nginx/uwsgi_params;
         uwsgi_param HTTP_X_FORWARDED_PROTO https;
         uwsgi_param X_NGINX_SOURCE internal;
+        uwsgi_param X_SSL_CLIENT_DN $ssl_client_s_dn;
+        uwsgi_param X_SSL_CLIENT_VERIFY $ssl_client_verify;
     }
 }

--- a/compose/nginx/nginx.conf
+++ b/compose/nginx/nginx.conf
@@ -16,5 +16,28 @@ server {
         uwsgi_pass django;
         include /etc/nginx/uwsgi_params;
         uwsgi_param HTTP_X_FORWARDED_PROTO https;
+        uwsgi_param X_NGINX_SOURCE alb;
+    }
+}
+
+server {
+    listen 8443 ssl;
+    server_name ~^(.+)$;
+    charset utf-8;
+
+    ssl_certificate     certs/#{DOMAIN}.crt;
+    ssl_certificate_key certs/#{DOMAIN}.key;
+
+    ssl_client_certificate certs/ca-bundle.crt;
+    ssl_verify_client on;
+    ssl_verify_depth 2;
+
+    client_max_body_size 25m;
+
+    location / {
+        uwsgi_pass django;
+        include /etc/nginx/uwsgi_params;
+        uwsgi_param HTTP_X_FORWARDED_PROTO https;
+        uwsgi_param X_NGINX_SOURCE engine;
     }
 }

--- a/compose/nginx/nginx.conf
+++ b/compose/nginx/nginx.conf
@@ -38,6 +38,6 @@ server {
         uwsgi_pass django;
         include /etc/nginx/uwsgi_params;
         uwsgi_param HTTP_X_FORWARDED_PROTO https;
-        uwsgi_param X_NGINX_SOURCE engine;
+        uwsgi_param X_NGINX_SOURCE internal;
     }
 }

--- a/conf/base.py
+++ b/conf/base.py
@@ -135,7 +135,7 @@ REST_FRAMEWORK = {
 
 if PROFILES_URL:
     REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
-        'apps.utils.PassiveJSONWebTokenAuthentication'
+        'apps.authentication.PassiveJSONWebTokenAuthentication'
     ),
     REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES'] = (
         'rest_framework.permissions.IsAuthenticated'

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,4 +24,14 @@ class AuthTests(TestCase):
         request.META['X_NGINX_SOURCE'] = 'alb'
         self.assertFalse(engine_request.has_permission(request, {}))
         request.META['X_NGINX_SOURCE'] = 'internal'
+        self.assertRaises(KeyError, engine_request.has_permission, request, {})
+        request.META['X_SSL_CLIENT_VERIFY'] = 'NONE'
+        self.assertFalse(engine_request.has_permission(request, {}))
+        request.META['X_SSL_CLIENT_VERIFY'] = 'SUCCESS'
+        self.assertRaises(KeyError, engine_request.has_permission, request, {})
+        request.META['X_SSL_CLIENT_DN'] = '/CN=engine.h4ck3d'
+        self.assertFalse(engine_request.has_permission(request, {}))
+        request.META['X_SSL_CLIENT_DN'] = '/CN=profiles.test-internal'
+        self.assertFalse(engine_request.has_permission(request, {}))
+        request.META['X_SSL_CLIENT_DN'] = '/CN=engine.test-internal'
         self.assertTrue(engine_request.has_permission(request, {}))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,16 @@
+from rest_framework import exceptions
+from django.test import TestCase
+
+from apps.authentication import PassiveJSONWebTokenAuthentication
+
+
+class AuthTests(TestCase):
+
+    def test_passive_jwt_auth(self):
+        auth = PassiveJSONWebTokenAuthentication()
+        self.assertRaises(exceptions.AuthenticationFailed, auth.authenticate_credentials, {})
+        user = auth.authenticate_credentials({'sub': '000-000-0000', 'username': 'wat@wat.com', 'email': 'wat@wat.com'})
+        self.assertEqual(user.is_authenticated(), True)
+        self.assertEqual(user.is_staff(), False)
+        self.assertEqual(user.is_superuser(), False)
+        self.assertEqual(user.username, 'wat@wat.com')

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,8 @@
 from rest_framework import exceptions
 from django.test import TestCase
+from django.http.request import HttpRequest
 
-from apps.authentication import PassiveJSONWebTokenAuthentication
+from apps.authentication import PassiveJSONWebTokenAuthentication, EngineRequest
 
 
 class AuthTests(TestCase):
@@ -14,3 +15,13 @@ class AuthTests(TestCase):
         self.assertEqual(user.is_staff(), False)
         self.assertEqual(user.is_superuser(), False)
         self.assertEqual(user.username, 'wat@wat.com')
+
+    def test_engine_auth_requires_header(self):
+        engine_request = EngineRequest()
+        request = HttpRequest()
+
+        self.assertFalse(engine_request.has_permission(request, {}))
+        request.META['X_NGINX_SOURCE'] = 'alb'
+        self.assertFalse(engine_request.has_permission(request, {}))
+        request.META['X_NGINX_SOURCE'] = 'engine'
+        self.assertTrue(engine_request.has_permission(request, {}))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -23,5 +23,5 @@ class AuthTests(TestCase):
         self.assertFalse(engine_request.has_permission(request, {}))
         request.META['X_NGINX_SOURCE'] = 'alb'
         self.assertFalse(engine_request.has_permission(request, {}))
-        request.META['X_NGINX_SOURCE'] = 'engine'
+        request.META['X_NGINX_SOURCE'] = 'internal'
         self.assertTrue(engine_request.has_permission(request, {}))

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -155,7 +155,7 @@ class JobsAPITests(APITestCase):
 
         error_message = {"type": "ERROR", "body": {"exception": "Test Exception"}}
 
-        response = self.client.post(url, json.dumps(error_message), content_type="application/json")
+        response = self.client.post(url, json.dumps(error_message), content_type="application/json", X_NGINX_SOURCE='engine')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         async_job = AsyncJob.objects.get(pk=self.async_jobs[1].id)
         self.assertEqual(async_job.state, JobState.FAILED)
@@ -189,7 +189,7 @@ class JobsAPITests(APITestCase):
             async_job = self.shipments[0].asyncjob_set.all()[:1].get()
             url = reverse('job-message', kwargs={'version': 'v1', 'pk': async_job.id})
 
-            response = self.client.post(url, json.dumps(success_message), content_type="application/json")
+            response = self.client.post(url, json.dumps(success_message), content_type="application/json", X_NGINX_SOURCE='engine')
             self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
             async_job = AsyncJob.objects.get(pk=async_job.id)
             self.assertEqual(async_job.state, JobState.COMPLETE)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -7,9 +7,8 @@ from moto import mock_iot
 
 from apps.shipments.models import Shipment
 from apps.jobs.models import AsyncJob, Message, MessageType, JobState
-from apps.rpc_client import RPCClient
 from apps.shipments.rpc import ShipmentRPCClient
-from apps.utils import AuthenticatedUser
+from apps.authentication import AuthenticatedUser
 
 MESSAGE = [
     {'type': 'message'}
@@ -177,7 +176,7 @@ class JobsAPITests(APITestCase):
 
         success_message = {"type": "ETH_TRANSACTION", "body": TRANSACTION_BODY}
 
-        with mock.patch.object(requests, 'post') as mock_method:
+        with mock.patch.object(requests.Session, 'post') as mock_method:
             mock_method.return_value = mocked_rpc_response({
                 "vault_id": VAULT_ID
             })

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -155,7 +155,7 @@ class JobsAPITests(APITestCase):
 
         error_message = {"type": "ERROR", "body": {"exception": "Test Exception"}}
 
-        response = self.client.post(url, json.dumps(error_message), content_type="application/json", X_NGINX_SOURCE='engine')
+        response = self.client.post(url, json.dumps(error_message), content_type="application/json", X_NGINX_SOURCE='internal')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         async_job = AsyncJob.objects.get(pk=self.async_jobs[1].id)
         self.assertEqual(async_job.state, JobState.FAILED)
@@ -189,7 +189,7 @@ class JobsAPITests(APITestCase):
             async_job = self.shipments[0].asyncjob_set.all()[:1].get()
             url = reverse('job-message', kwargs={'version': 'v1', 'pk': async_job.id})
 
-            response = self.client.post(url, json.dumps(success_message), content_type="application/json", X_NGINX_SOURCE='engine')
+            response = self.client.post(url, json.dumps(success_message), content_type="application/json", X_NGINX_SOURCE='internal')
             self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
             async_job = AsyncJob.objects.get(pk=async_job.id)
             self.assertEqual(async_job.state, JobState.COMPLETE)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -155,7 +155,7 @@ class JobsAPITests(APITestCase):
 
         error_message = {"type": "ERROR", "body": {"exception": "Test Exception"}}
 
-        response = self.client.post(url, json.dumps(error_message), content_type="application/json", X_NGINX_SOURCE='internal')
+        response = self.client.post(url, json.dumps(error_message), content_type="application/json", X_NGINX_SOURCE='internal', X_SSL_CLIENT_VERIFY='SUCCESS', X_SSL_CLIENT_DN='/CN=engine.test-internal')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         async_job = AsyncJob.objects.get(pk=self.async_jobs[1].id)
         self.assertEqual(async_job.state, JobState.FAILED)
@@ -189,7 +189,7 @@ class JobsAPITests(APITestCase):
             async_job = self.shipments[0].asyncjob_set.all()[:1].get()
             url = reverse('job-message', kwargs={'version': 'v1', 'pk': async_job.id})
 
-            response = self.client.post(url, json.dumps(success_message), content_type="application/json", X_NGINX_SOURCE='internal')
+            response = self.client.post(url, json.dumps(success_message), content_type="application/json", X_NGINX_SOURCE='internal', X_SSL_CLIENT_VERIFY='SUCCESS', X_SSL_CLIENT_DN='/CN=engine.test-internal')
             self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
             async_job = AsyncJob.objects.get(pk=async_job.id)
             self.assertEqual(async_job.state, JobState.COMPLETE)

--- a/tests/test_shipments.py
+++ b/tests/test_shipments.py
@@ -110,7 +110,7 @@ class ShipmentAPITests(APITestCase):
         certificate_id = cert_response['certificateId']
 
         # Set device for Shipment
-        with mock.patch.object(requests, 'post') as mock_method:
+        with mock.patch.object(requests.Session, 'post') as mock_method:
             mock_method.return_value = mocked_rpc_response({
                 "jsonrpc": "2.0",
                 "result": {

--- a/tests/test_shipments.py
+++ b/tests/test_shipments.py
@@ -19,7 +19,8 @@ from unittest.mock import patch
 from apps.shipments.models import Shipment, Location, LoadShipment, FundingType, EscrowStatus, ShipmentStatus, Device
 from apps.shipments.rpc import ShipmentRPCClient
 from django.contrib.gis.geos import Point
-from apps.utils import AuthenticatedUser, random_id
+from apps.authentication import AuthenticatedUser
+from apps.utils import random_id
 from tests.utils import replace_variables_in_string, create_form_content
 
 VAULT_ID = 'b715a8ff-9299-4c87-96de-a4b0a4a54509'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
-from rest_framework import exceptions
 from django.test import TestCase
 
-from apps.utils import assertDeepAlmostEqual, PassiveJSONWebTokenAuthentication
+from apps.utils import assertDeepAlmostEqual
 
 
 class UtilsTests(TestCase):
@@ -25,12 +24,3 @@ class UtilsTests(TestCase):
                           actual={
                               'testing': 124
                           })
-
-    def test_passive_jwt_auth(self):
-        auth = PassiveJSONWebTokenAuthentication()
-        self.assertRaises(exceptions.AuthenticationFailed, auth.authenticate_credentials, {})
-        user = auth.authenticate_credentials({'sub': '000-000-0000', 'username': 'wat@wat.com', 'email': 'wat@wat.com'})
-        self.assertEqual(user.is_authenticated(), True)
-        self.assertEqual(user.is_staff(), False)
-        self.assertEqual(user.is_superuser(), False)
-        self.assertEqual(user.username, 'wat@wat.com')


### PR DESCRIPTION
These changes are required for Transmission to work with our SSL mututal certificate auth infrastructure changes.

- Add Nginx config for SSL
- Add entrypoint logic load certificates from AWS ACM in deployed environments
- Specify certificate and CA in rpc-client.py
- Job messages and events are protected by the `EngineRequest` permission class, which restricts callers to the internal SSL port in Nginx