### PR TITLE
Use global requests session for passing client certificate

### DIFF
--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -7,7 +7,6 @@ from geocoder.keys import mapbox_access_token
 
 import boto3
 
-import requests
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.gis.db.models import GeometryField
@@ -110,8 +109,8 @@ class Device(models.Model):
         certificate_id = None
         if settings.PROFILES_URL:
             # Make a request to Profiles /api/v1/devices/{device_id} with the user's JWT
-            response = requests.get(f'{settings.PROFILES_URL}/api/v1/device/{device_id}/',
-                                    headers={'Authorization': 'JWT {}'.format(jwt.decode())})
+            response = settings.REQUESTS_SESSION.get(f'{settings.PROFILES_URL}/api/v1/device/{device_id}/',
+                                                     headers={'Authorization': 'JWT {}'.format(jwt.decode())})
             if response.status_code != status.HTTP_200_OK:
                 raise PermissionDenied("User does not have access to this device in ShipChain Profiles")
 

--- a/conf/__init__.py
+++ b/conf/__init__.py
@@ -4,4 +4,6 @@ from .auth import *
 
 from .celery import *
 
+from .requests import *
+
 from .apps import *

--- a/conf/requests.py
+++ b/conf/requests.py
@@ -1,0 +1,26 @@
+"""
+Copyright 2018 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import requests
+
+from .base import ENVIRONMENT
+
+REQUESTS_SESSION = requests.session()
+
+if ENVIRONMENT in ('PROD', 'STAGE', 'DEV', 'DEMO'):
+    REQUESTS_SESSION.cert = ('/app/client-cert.crt', '/app/client-cert.key')
+    REQUESTS_SESSION.verify = '/app/ca-bundle.crt'
+REQUESTS_SESSION.headers = {'content-type': 'application/json'}


### PR DESCRIPTION
A global `requests` session should be used to reduce the amount of places the client certificate needs to be specified for external service requests.

- Added `conf/requests.py` where the session is defined
- Modified rpc_client.py to use this session
- Changed device creation Profiles call to use this session (and therefore the client cert)