### PR TITLE
Add wallet authentication check using profiles

### DIFF
--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -16,10 +16,8 @@ from django.core.validators import RegexValidator
 from django.db import models
 from enumfields import Enum
 from enumfields import EnumField
-from rest_framework import status
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.exceptions import ValidationError, Throttled
-from rest_framework.status import HTTP_500_INTERNAL_SERVER_ERROR, HTTP_503_SERVICE_UNAVAILABLE
+from rest_framework.exceptions import ValidationError, Throttled, PermissionDenied
+from rest_framework.status import HTTP_200_OK, HTTP_500_INTERNAL_SERVER_ERROR, HTTP_503_SERVICE_UNAVAILABLE
 from influxdb_metrics.loader import log_metric
 
 from apps.eth.models import EthListener
@@ -111,7 +109,7 @@ class Device(models.Model):
             # Make a request to Profiles /api/v1/devices/{device_id} with the user's JWT
             response = settings.REQUESTS_SESSION.get(f'{settings.PROFILES_URL}/api/v1/device/{device_id}/',
                                                      headers={'Authorization': 'JWT {}'.format(jwt.decode())})
-            if response.status_code != status.HTTP_200_OK:
+            if response.status_code != HTTP_200_OK:
                 raise PermissionDenied("User does not have access to this device in ShipChain Profiles")
 
         if settings.ENVIRONMENT != 'LOCAL':

--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -140,6 +140,8 @@ class ShipmentCreateSerializer(ShipmentSerializer):
             if response.status_code != status.HTTP_200_OK:
                 raise serializers.ValidationError('User does not have access to this wallet in ShipChain Profiles')
 
+        return shipper_wallet_id
+
 
 class ShipmentUpdateSerializer(ShipmentSerializer):
     device_id = serializers.CharField(max_length=36)

--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -7,7 +7,6 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.db import transaction
 from enumfields.drf import EnumField
 from enumfields.drf.serializers import EnumSupportSerializerMixin
@@ -132,18 +131,14 @@ class ShipmentCreateSerializer(ShipmentSerializer):
 
             return Shipment.objects.create(**validated_data, **extra_args)
 
-    def validate_wallet_ownership(self, shipper_wallet_id):
+    def validate_shipper_wallet_id(self, shipper_wallet_id):
         if settings.PROFILES_URL:
-            print('Self.context: ', self.context['auth'])
             auth = self.context['auth']
-            print('Auth decoded: ', auth.decode())
-
             response = settings.REQUESTS_SESSION.get(f'{settings.PROFILES_URL}/api/v1/wallet/{shipper_wallet_id}/',
                                                      headers={'Authorization': 'JWT {}'.format(auth.decode())})
 
             if response.status_code != status.HTTP_200_OK:
-                raise ValidationError({'shipper_wallet_id':
-                                       'User does not have access to this wallet in ShipChain Profiles'})
+                raise serializers.ValidationError('User does not have access to this wallet in ShipChain Profiles')
 
 
 class ShipmentUpdateSerializer(ShipmentSerializer):

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -48,6 +48,8 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         # Create Shipment
         serializer = ShipmentCreateSerializer(data=request.data, context={'auth': request.auth})
         serializer.is_valid(raise_exception=True)
+        print('Request.ath: ', request.auth)
+        serializer.validate_wallet_ownership(request.data['shipper_wallet_id'])
 
         shipment = self.perform_create(serializer)
         async_job = shipment.asyncjob_set.all()[:1]

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -48,8 +48,6 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         # Create Shipment
         serializer = ShipmentCreateSerializer(data=request.data, context={'auth': request.auth})
         serializer.is_valid(raise_exception=True)
-        print('Request.ath: ', request.auth)
-        serializer.validate_wallet_ownership(request.data['shipper_wallet_id'])
 
         shipment = self.perform_create(serializer)
         async_job = shipment.asyncjob_set.all()[:1]


### PR DESCRIPTION
It is important to make sure that whoever makes a shipment has ownership/usage of the wallet that is to fund said shipment. The most efficient way to do so is through a get request to profiles, using the JWT originally used to create the shipment.