### PR TITLE
Websocket Support (AsyncJob Notifications)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,14 +30,9 @@ jobs:
             docker-compose -f compose/circleci.yml exec -T runserver prospector -o pylint
 
       - run:
-          name: Run unit tests
+          name: Run unit tests and coverage report
           command: |
-            docker-compose -f compose/circleci.yml exec -T runserver coverage run manage.py test --noinput tests --settings conf.test_settings
-
-      - run:
-          name: Unit test coverage report
-          command: |
-            docker-compose -f compose/circleci.yml exec -T runserver coverage xml -o test-results/coverage/results.xml
+            docker-compose -f compose/circleci.yml exec -T runserver pytest --junitxml=test-results/junit.xml --cov=apps --cov-config=.coveragerc --cov-report=xml:test-results/coverage.xml
 
       - run:
           name: Copy artifacts from Docker

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 include = apps/*
 omit =
     apps/*/migrations/*
+    apps/asgi.py
     apps/wsgi.py
     apps/celery.py
 

--- a/apps/asgi.py
+++ b/apps/asgi.py
@@ -1,0 +1,30 @@
+"""
+Copyright 2018 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+
+import django
+import dotenv
+from channels.routing import get_default_application
+
+# ASGI entrypoint. Configures Django and then runs the application
+# defined in the ASGI_APPLICATION setting.
+
+dotenv.read_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+django.setup()
+# pylint:disable=invalid-name
+application = get_default_application()

--- a/apps/authentication.py
+++ b/apps/authentication.py
@@ -66,11 +66,12 @@ class AsyncJsonAuthConsumer(AsyncJsonWebsocketConsumer):
     """
     async def connect(self):
         if await self._authenticate():
-            await self.channel_layer.group_add("jobs", self.channel_name)
+            await self.channel_layer.group_add(self.scope['user'].id, self.channel_name)
             await self.accept('base64.authentication.jwt')
 
     async def disconnect(self, code):
-        await self.channel_layer.group_discard("jobs", self.channel_name)
+        if self.scope['user']:
+            await self.channel_layer.group_discard(self.scope['user'].id, self.channel_name)
         await super().disconnect(code)
 
     async def receive(self, text_data=None, bytes_data=None, **kwargs):

--- a/apps/authentication.py
+++ b/apps/authentication.py
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from asgiref import sync
 from collections import namedtuple
 from django.conf import settings
-from channels.auth import BaseMiddleware, UserLazyObject
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from rest_framework import exceptions
 from rest_framework.permissions import BasePermission
@@ -42,56 +42,22 @@ class AuthenticatedUser:
         return False
 
 
+def passive_credentials_authentication(payload):
+    if 'sub' not in payload:
+        raise exceptions.AuthenticationFailed('Invalid payload.')
+
+    payload['pk'] = payload['sub']
+    payload = namedtuple("User", payload.keys())(*payload.values())
+    payload = api_settings.JWT_PAYLOAD_HANDLER(payload)
+
+    user = AuthenticatedUser(payload)
+
+    return user
+
+
 class PassiveJSONWebTokenAuthentication(JSONWebTokenAuthentication):
     def authenticate_credentials(self, payload):
-        if 'sub' not in payload:
-            raise exceptions.AuthenticationFailed('Invalid payload.')
-
-        payload['pk'] = payload['sub']
-        payload = namedtuple("User", payload.keys())(*payload.values())
-        payload = api_settings.JWT_PAYLOAD_HANDLER(payload)
-
-        user = AuthenticatedUser(payload)
-
-        return user
-
-
-class ChannelsJWTMiddleware(BaseMiddleware, PassiveJSONWebTokenAuthentication):
-    """
-    Middleware which populates scope["user"] from a JWT.
-    """
-
-    def populate_scope(self, scope):
-        # Add it to the scope if it's not there already
-        if "user" not in scope:
-            scope["user"] = UserLazyObject()
-
-    async def resolve_scope(self, scope):
-        if "jwt" not in scope:
-            scope["jwt"] = self._get_jwt_from_subprotocols(scope)
-        scope["user"]._wrapped = self._get_user(scope)
-
-    def _get_jwt_from_subprotocols(self, scope):
-        jwt = None
-
-        # Initially parse jwt out of subprotocols
-        for protocol in scope['subprotocols']:
-            if protocol.startswith('base64.jwt.'):
-                jwt = protocol.split('base64.jwt.')[1]
-
-        return jwt
-
-    def _get_user(self, scope):
-        user = None
-
-        try:
-            if scope['jwt']:
-                payload = jwt_decode_handler(scope['jwt'])
-                user = self.authenticate_credentials(payload)
-        except Exception:
-            pass
-
-        return user
+        return passive_credentials_authentication(payload)
 
 
 class AsyncJsonAuthConsumer(AsyncJsonWebsocketConsumer):
@@ -99,9 +65,7 @@ class AsyncJsonAuthConsumer(AsyncJsonWebsocketConsumer):
     Consumer that requires user to be present in the scope.
     """
     async def connect(self):
-        if not self.scope['user']._wrapped:
-            await self.close()
-        else:
+        if await self._authenticate():
             await self.channel_layer.group_add("jobs", self.channel_name)
             await self.accept('base64.authentication.jwt')
 
@@ -110,23 +74,51 @@ class AsyncJsonAuthConsumer(AsyncJsonWebsocketConsumer):
         await super().disconnect(code)
 
     async def receive(self, text_data=None, bytes_data=None, **kwargs):
-        if not self.scope['user']._wrapped:
-            await self.close()
-        else:
+        if await self._authenticate():
             if text_data:
                 json = await self.decode_json(text_data)
                 if 'event' in json and 'data' in json and json['event'] == 'refresh_jwt':
-                    self.scope['jwt'] = text_data['data']
+                    self.scope['jwt'] = json['data']
                 else:
                     await self.receive_json(json, **kwargs)
             else:
                 raise ValueError("No text section for incoming WebSocket frame!")
 
     async def send(self, text_data=None, bytes_data=None, close=False):
-        if not self.scope['user']._wrapped:
-            await self.close()
-        else:
+        if await self._authenticate():
             await super().send(text_data, bytes_data, close)
+
+    async def _authenticate(self):
+        if "jwt" not in self.scope:
+            self.scope["jwt"] = await self._get_jwt_from_subprotocols()
+        self.scope["user"] = await self._get_user()
+        if not self.scope['user'] or ('user_id' in self.scope['url_route']['kwargs'] and
+                                      self.scope['url_route']['kwargs']['user_id'] != self.scope['user'].id):
+            await self.close()
+            return False
+        return True
+
+    async def _get_jwt_from_subprotocols(self):
+        jwt = None
+
+        # Initially parse jwt out of subprotocols
+        for protocol in self.scope['subprotocols']:
+            if protocol.startswith('base64.jwt.'):
+                jwt = protocol.split('base64.jwt.')[1]
+
+        return jwt
+
+    async def _get_user(self):
+        user = None
+
+        try:
+            if self.scope['jwt']:
+                payload = await sync.sync_to_async(jwt_decode_handler)(self.scope['jwt'])
+                user = await sync.sync_to_async(passive_credentials_authentication)(payload)
+        except Exception:
+            pass
+
+        return user
 
 
 class EngineRequest(BasePermission):

--- a/apps/authentication.py
+++ b/apps/authentication.py
@@ -16,10 +16,12 @@ limitations under the License.
 
 from collections import namedtuple
 from django.conf import settings
+from channels.auth import BaseMiddleware, UserLazyObject
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from rest_framework import exceptions
 from rest_framework.permissions import BasePermission
 from rest_framework_jwt.settings import api_settings
-from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+from rest_framework_jwt.authentication import JSONWebTokenAuthentication, jwt_decode_handler
 
 from .utils import parse_dn
 
@@ -52,6 +54,79 @@ class PassiveJSONWebTokenAuthentication(JSONWebTokenAuthentication):
         user = AuthenticatedUser(payload)
 
         return user
+
+
+class ChannelsJWTMiddleware(BaseMiddleware, PassiveJSONWebTokenAuthentication):
+    """
+    Middleware which populates scope["user"] from a JWT.
+    """
+
+    def populate_scope(self, scope):
+        # Add it to the scope if it's not there already
+        if "user" not in scope:
+            scope["user"] = UserLazyObject()
+
+    async def resolve_scope(self, scope):
+        if "jwt" not in scope:
+            scope["jwt"] = self._get_jwt_from_subprotocols(scope)
+        scope["user"]._wrapped = self._get_user(scope)
+
+    def _get_jwt_from_subprotocols(self, scope):
+        jwt = None
+
+        # Initially parse jwt out of subprotocols
+        for protocol in scope['subprotocols']:
+            if protocol.startswith('base64.jwt.'):
+                jwt = protocol.split('base64.jwt.')[1]
+
+        return jwt
+
+    def _get_user(self, scope):
+        user = None
+
+        try:
+            if scope['jwt']:
+                payload = jwt_decode_handler(scope['jwt'])
+                user = self.authenticate_credentials(payload)
+        except Exception:
+            pass
+
+        return user
+
+
+class AsyncJsonAuthConsumer(AsyncJsonWebsocketConsumer):
+    """
+    Consumer that requires user to be present in the scope.
+    """
+    async def connect(self):
+        if not self.scope['user']._wrapped:
+            await self.close()
+        else:
+            await self.channel_layer.group_add("jobs", self.channel_name)
+            await self.accept('base64.authentication.jwt')
+
+    async def disconnect(self, code):
+        await self.channel_layer.group_discard("jobs", self.channel_name)
+        await super().disconnect(code)
+
+    async def receive(self, text_data=None, bytes_data=None, **kwargs):
+        if not self.scope['user']._wrapped:
+            await self.close()
+        else:
+            if text_data:
+                json = await self.decode_json(text_data)
+                if 'event' in json and 'data' in json and json['event'] == 'refresh_jwt':
+                    self.scope['jwt'] = text_data['data']
+                else:
+                    await self.receive_json(json, **kwargs)
+            else:
+                raise ValueError("No text section for incoming WebSocket frame!")
+
+    async def send(self, text_data=None, bytes_data=None, close=False):
+        if not self.scope['user']._wrapped:
+            await self.close()
+        else:
+            await super().send(text_data, bytes_data, close)
 
 
 class EngineRequest(BasePermission):

--- a/apps/exceptions.py
+++ b/apps/exceptions.py
@@ -163,7 +163,7 @@ def invalid_url(request, exception, *args, **kwargs):
     """
     data = {
         "errors": [{
-            "detail": "Error 404, page not foud",
+            "detail": "Error 404, page not found",
             "status": "404"
         }]
     }

--- a/apps/jobs/consumers.py
+++ b/apps/jobs/consumers.py
@@ -1,0 +1,38 @@
+"""
+Copyright 2018 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from channels.db import database_sync_to_async
+from rest_framework.renderers import JSONRenderer
+from apps.authentication import AsyncJsonAuthConsumer
+from .models import AsyncJob
+from .serializers import AsyncJobSerializer
+
+
+class JobsConsumer(AsyncJsonAuthConsumer):
+    async def jobs_update(self, event):
+        job_json = await database_sync_to_async(self.render_async_job)(event['async_job_id'])
+        await self.send(job_json)
+
+    def render_async_job(self, job_id):
+        job = AsyncJob.objects.get(id=job_id)
+        return JSONRenderer().render(AsyncJobSerializer(job).data).decode()
+
+    async def receive_json(self, content, **kwargs):
+        user_id = self.scope["url_route"]["kwargs"]["user_id"]
+        await self.send_json({
+            "user_id": user_id,
+            "error": "This websocket endpoint is read-only",
+        })

--- a/apps/jobs/consumers.py
+++ b/apps/jobs/consumers.py
@@ -35,11 +35,11 @@ class JobsConsumer(AsyncJsonAuthConsumer):
 
     def render_async_job(self, job_id):
         job = AsyncJob.objects.get(id=job_id)
-        return JSONRenderer().render({'event': str(EventTypes.asyncjob_update),
+        return JSONRenderer().render({'event': EventTypes.asyncjob_update.name,
                                       'data': AsyncJobSerializer(job).data}).decode()
 
     async def receive_json(self, content, **kwargs):
         await self.send_json({
-            "event": str(EventTypes.error),
+            "event": EventTypes.error.name,
             "data": "This websocket endpoint is read-only",
         })

--- a/apps/jobs/models.py
+++ b/apps/jobs/models.py
@@ -51,7 +51,7 @@ class AsyncJob(models.Model):
     @staticmethod
     def rpc_job_for_listener(rpc_method, rpc_parameters, signing_wallet_id, listener, delay=0):
         rpc_module = rpc_method.__module__
-        rpc_class, rpc_method = rpc_method.__qualname__.rsplit('.')
+        rpc_class, rpc_method = rpc_method.__qualname__.rsplit('.')[-2:]
         job = AsyncJob.objects.create(parameters={
             'rpc_class': f'{rpc_module}.{rpc_class}',
             'rpc_method': f'{rpc_method}',

--- a/apps/jobs/permissions.py
+++ b/apps/jobs/permissions.py
@@ -1,0 +1,16 @@
+from rest_framework import permissions
+
+
+class IsOwner(permissions.BasePermission):
+    """
+    Custom permission to only allow owners of an object to edit it
+    """
+
+    def has_object_permission(self, request, view, obj):
+
+        # Permissions are allowed to anyone who owns a shipment listening to this job
+        is_owner = False
+        for shipment in obj.listeners.filter(Model='shipments.Shipment'):
+            if shipment.owner_id == request.user.id:
+                is_owner = True
+        return is_owner

--- a/apps/jobs/routing.py
+++ b/apps/jobs/routing.py
@@ -14,12 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from channels.routing import ProtocolTypeRouter, URLRouter
-import apps.jobs.routing
+from django.conf.urls import url
 
-application = ProtocolTypeRouter({
-    # (http->django views is added by default)
-    'websocket': URLRouter(
-        apps.jobs.routing.websocket_urlpatterns
-    ),
-})
+from . import consumers
+
+websocket_urlpatterns = [
+    url(r'^ws/(?P<user_id>[^/]+)/notifications$', consumers.JobsConsumer),
+]

--- a/apps/jobs/routing.py
+++ b/apps/jobs/routing.py
@@ -18,6 +18,7 @@ from django.conf.urls import url
 
 from . import consumers
 
+# pylint:disable=invalid-name
 websocket_urlpatterns = [
     url(r'^ws/(?P<user_id>[^/]+)/notifications$', consumers.JobsConsumer),
 ]

--- a/apps/jobs/signals.py
+++ b/apps/jobs/signals.py
@@ -40,4 +40,3 @@ def message_post_save(sender, instance, **kwargs):
                         message=instance, listener=listener.listener)
         async_to_sync(channel_layer.group_send)(listener.listener.owner_id,
                                                 {"type": "jobs.update", "async_job_id": instance.async_job.id})
-

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -1,6 +1,7 @@
 import logging
 
-from rest_framework import viewsets, mixins, parsers, status, renderers
+from django.conf import settings
+from rest_framework import viewsets, mixins, permissions, parsers, status, renderers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework_json_api import parsers as jsapi_parsers
@@ -8,6 +9,7 @@ from influxdb_metrics.loader import log_metric
 
 from apps.authentication import EngineRequest
 from .models import AsyncJob
+from .permissions import IsOwner
 from .serializers import AsyncJobSerializer, MessageSerializer
 
 LOG = logging.getLogger('transmission')
@@ -21,7 +23,14 @@ class JobsViewSet(mixins.ListModelMixin,
     """
     queryset = AsyncJob.objects.all()
     serializer_class = AsyncJobSerializer
+    permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL else (permissions.AllowAny,)
     parser_classes = (parsers.JSONParser, jsapi_parsers.JSONParser)
+
+    def get_queryset(self):
+        queryset = self.queryset
+        if settings.PROFILES_URL:
+            queryset = queryset.filter(joblistener__shipments__owner_id=self.request.user.id)
+        return queryset
 
     @action(detail=True, methods=['post'],
             permission_classes=[EngineRequest],

--- a/apps/routing.py
+++ b/apps/routing.py
@@ -1,0 +1,21 @@
+"""
+Copyright 2018 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from channels.routing import ProtocolTypeRouter
+
+application = ProtocolTypeRouter({
+    # Empty for now (http->django views is added by default)
+})

--- a/apps/routing.py
+++ b/apps/routing.py
@@ -17,6 +17,7 @@ limitations under the License.
 from channels.routing import ProtocolTypeRouter, URLRouter
 import apps.jobs.routing
 
+# pylint:disable=invalid-name
 application = ProtocolTypeRouter({
     # (http->django views is added by default)
     'websocket': URLRouter(

--- a/bin/docker_tests
+++ b/bin/docker_tests
@@ -17,6 +17,6 @@ bin/dc up -d
 
 bin/dc exec -T runserver prospector -o pylint
 
-bin/dc exec -T runserver pytest --cov=apps --cov-config=.coveragerc
+bin/dc exec -T runserver pytest -p no:cacheprovider --cov=apps --cov-config=.coveragerc
 
 bin/dc down

--- a/bin/docker_tests
+++ b/bin/docker_tests
@@ -9,14 +9,14 @@ cd "${0%/*}/.."
 
 echo "Running tests"
 
+find -name "*.pyc" -delete
+
 bin/dc build
 
 bin/dc up -d
 
 bin/dc exec -T runserver prospector -o pylint
 
-bin/dc exec -T runserver coverage run manage.py test --noinput tests --settings conf.test_settings
-
-bin/dc exec -T runserver coverage report
+bin/dc exec -T runserver pytest --cov=apps --cov-config=.coveragerc
 
 bin/dc down

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -63,6 +63,7 @@ services:
       - ../:/app
       - ./django/pip.cache:/build/pip.volume
     environment:
+      - PYTHONDONTWRITEBYTECODE=1
       - ENV
       - SECRET_KEY
       - SERVICE=runserver

--- a/compose/django/requirements.txt
+++ b/compose/django/requirements.txt
@@ -1,3 +1,4 @@
+aioredis==1.2.0
 amqp==2.2.2
 argh==0.26.2
 asgiref==2.3.2
@@ -20,6 +21,7 @@ celery-once==2.0.0
 certifi==2018.1.18
 cffi==1.11.5
 channels==2.1.5
+channels-redis==2.3.1
 chardet==3.0.4
 click==6.7
 -e git://github.com/kusha/python-elasticsearch-logger.git@91b458a58e12ab1e9a8fe16a28d225f610e29183#egg=CMRESHandler
@@ -66,6 +68,7 @@ geocoder==1.38.1
 geojson==2.4.0
 greenlet==0.4.15
 gunicorn==19.7.1
+hiredis==0.2.0
 httpretty==0.9.5
 hyperlink==18.0.0
 idna==2.6

--- a/compose/django/requirements.txt
+++ b/compose/django/requirements.txt
@@ -5,6 +5,7 @@ asgiref==2.3.2
 asn1crypto==0.24.0
 astroid==1.6.1
 async-timeout==3.0.1
+atomicwrites==1.2.1
 attrs==18.2.0
 autobahn==18.10.1
 Automat==0.7.0
@@ -90,16 +91,19 @@ Markdown==2.6.11
 MarkupSafe==1.0
 mccabe==0.6.1
 mock==2.0.0
+more-itertools==4.3.0
 -e git://github.com/ShipChain/moto.git@e7f9d7c6bfb9098e66785d810af726d740e0632d#egg=moto
 msgpack==0.5.6
 openapi-codec==1.3.2
 pathtools==0.1.2
 pbr==4.2.0
 pep8-naming==0.5.0
+pluggy==0.8.0
 polyline==1.3.2
 prospector==0.12.7
 psutil==5.4.5
 psycopg2==2.7.4
+py==1.7.0
 pyaml==17.12.1
 pyasn1==0.4.2
 pycodestyle==2.0.0
@@ -118,6 +122,10 @@ pylint-flask==0.5
 pylint-plugin-utils==0.2.6
 pyOpenSSL==17.5.0
 pysha3==1.0.2
+pytest==3.9.3
+pytest-asyncio==0.9.0
+pytest-cov==2.6.0
+pytest-django==3.4.3
 python-dateutil==2.7.2
 python-jose==3.0.1
 python-server-metrics==0.2.1
@@ -144,7 +152,6 @@ Twisted==18.9.0
 txaio==18.8.1
 typing==3.6.6
 Unidecode==1.0.22
-unittest-xml-reporting==2.1.1
 uritemplate==3.0.0
 urllib3==1.22
 uWSGI==2.0.17.1

--- a/compose/django/requirements.txt
+++ b/compose/django/requirements.txt
@@ -46,6 +46,7 @@ django-extensions==2.0.6
 django-filter==1.1.0
 django-gm2m==0.6.1
 -e git://github.com/lwbco/django-influxdb-tagged-metrics.git@add895558ed6ab59c621b19beae026f8933d4848#egg=django_influxdb_metrics
+django-mock-queries==2.1.1
 django-redis==4.9.0
 djangorestframework==3.8.2
 djangorestframework-gis==0.13
@@ -91,6 +92,7 @@ Markdown==2.6.11
 MarkupSafe==1.0
 mccabe==0.6.1
 mock==2.0.0
+model-mommy==1.6.0
 more-itertools==4.3.0
 -e git://github.com/ShipChain/moto.git@e7f9d7c6bfb9098e66785d810af726d740e0632d#egg=moto
 msgpack==0.5.6

--- a/compose/django/requirements.txt
+++ b/compose/django/requirements.txt
@@ -1,7 +1,12 @@
 amqp==2.2.2
 argh==0.26.2
+asgiref==2.3.2
 asn1crypto==0.24.0
 astroid==1.6.1
+async-timeout==3.0.1
+attrs==18.2.0
+autobahn==18.10.1
+Automat==0.7.0
 aws-xray-sdk==0.95
 billiard==3.5.0.3
 blessings==1.7
@@ -14,10 +19,12 @@ celery==4.2.1
 celery-once==2.0.0
 certifi==2018.1.18
 cffi==1.11.5
+channels==2.1.5
 chardet==3.0.4
 click==6.7
 -e git://github.com/kusha/python-elasticsearch-logger.git@91b458a58e12ab1e9a8fe16a28d225f610e29183#egg=CMRESHandler
 colorama==0.3.7
+constantly==15.1.0
 cookies==2.2.1
 coreapi==2.3.3
 coreschema==0.0.4
@@ -25,6 +32,7 @@ coverage==4.5.1
 cryptography==2.3.1
 curtsies==0.3.0
 cytoolz==0.9.0
+daphne==2.2.2
 decorator==4.3.0
 Django==2.0.9
 django-cors-headers==2.2.0
@@ -59,7 +67,9 @@ geojson==2.4.0
 greenlet==0.4.15
 gunicorn==19.7.1
 httpretty==0.9.5
+hyperlink==18.0.0
 idna==2.6
+incremental==17.5.0
 inflection==0.3.1
 influxdb==5.0.0
 iso3166==0.9
@@ -95,6 +105,7 @@ pycryptodome==3.6.6
 pydocstyle==2.1.1
 pyflakes==1.6.0
 Pygments==2.2.0
+PyHamcrest==1.9.0
 PyJWT==1.6.4
 pylint==1.8.2
 pylint-celery==0.3
@@ -126,6 +137,8 @@ snowballstemmer==1.2.1
 termstyle==0.1.11
 tld==0.7.10
 toolz==0.9.0
+Twisted==18.9.0
+txaio==18.8.1
 typing==3.6.6
 Unidecode==1.0.22
 unittest-xml-reporting==2.1.1
@@ -140,3 +153,4 @@ Werkzeug==0.14.1
 whitenoise==3.3.1
 wrapt==1.10.11
 xmltodict==0.11.0
+zope.interface==4.6.0

--- a/compose/nginx/entrypoint.sh
+++ b/compose/nginx/entrypoint.sh
@@ -45,6 +45,6 @@ echo $CA_CERT_JSON | jq -r '.CertificateChain' >> /etc/nginx/certs/ca-bundle.crt
 openssl rsa -passin pass:$CERT_PASS -in /etc/nginx/certs/$SUBDOMAIN.encrypted.key -out /etc/nginx/certs/$SUBDOMAIN.key
 
 # Update nginx.conf with app name and environment
-sed -i "s/#{DOMAIN}/$SUBDOMAIN/g" /etc/nginx/conf.d/default.conf
+sed -i "s/#{INTERNAL_DOMAIN}/$SUBDOMAIN/g" /etc/nginx/conf.d/default.conf
 
 exec "$@"

--- a/compose/nginx/nginx.conf
+++ b/compose/nginx/nginx.conf
@@ -1,32 +1,59 @@
-upstream django {
+upstream uwsgi {
     server 127.0.0.1:8000;
 }
 
+upstream daphne {
+    server 127.0.0.1:8001;
+}
+
+# Handle vanilla HTTPS with non -ws subdomain
 server {
     listen 443 ssl;
-    server_name ~^(.+)$;
+
+    server_name ~^[\w]+(?!-ws)(?:-[\w]+)?.(?:ops.)?shipchain.io$;
     charset utf-8;
 
-    ssl_certificate     certs/#{DOMAIN}.crt;
-    ssl_certificate_key certs/#{DOMAIN}.key;
+    ssl_certificate     certs/#{INTERNAL_DOMAIN}.crt;
+    ssl_certificate_key certs/#{INTERNAL_DOMAIN}.key;
 
     client_max_body_size 25m;
 
     location / {
-        uwsgi_pass django;
+        uwsgi_pass uwsgi;
         include /etc/nginx/uwsgi_params;
         uwsgi_param HTTP_X_FORWARDED_PROTO https;
         uwsgi_param X_NGINX_SOURCE alb;
     }
 }
 
+# Handle WSS requests with -ws subdomain
 server {
-    listen 8443 ssl;
-    server_name ~^(.+)$;
+    listen 443 ssl;
+
+    server_name ~^[\w]+(?:-[\w]+)?-ws.(?:ops.)?shipchain.io$;
     charset utf-8;
 
-    ssl_certificate     certs/#{DOMAIN}.crt;
-    ssl_certificate_key certs/#{DOMAIN}.key;
+    ssl_certificate     certs/#{INTERNAL_DOMAIN}.crt;
+    ssl_certificate_key certs/#{INTERNAL_DOMAIN}.key;
+
+    client_max_body_size 25m;
+
+    location / {
+        proxy_pass ws://daphne/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X_NGINX_SOURCE ws;
+    }
+}
+
+server {
+    listen 8443 ssl;
+    server_name #{INTERNAL_DOMAIN};
+    charset utf-8;
+
+    ssl_certificate     certs/#{INTERNAL_DOMAIN}.crt;
+    ssl_certificate_key certs/#{INTERNAL_DOMAIN}.key;
 
     ssl_client_certificate certs/ca-bundle.crt;
     ssl_verify_client on;
@@ -35,7 +62,7 @@ server {
     client_max_body_size 25m;
 
     location / {
-        uwsgi_pass django;
+        uwsgi_pass uwsgi;
         include /etc/nginx/uwsgi_params;
         uwsgi_param HTTP_X_FORWARDED_PROTO https;
         uwsgi_param X_NGINX_SOURCE internal;

--- a/conf/base.py
+++ b/conf/base.py
@@ -200,6 +200,16 @@ STATICFILES_DIRS = [
 ]
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
+# Channels
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [os.environ.get('REDIS_URL', default='redis://:redis_pass@redis_db:6379/1')],
+        },
+    },
+}
+
 # Password validation
 # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators
 

--- a/conf/base.py
+++ b/conf/base.py
@@ -106,6 +106,7 @@ INSTALLED_APPS = [
     'apps.eth',
     'apps.shipments',
     'apps.schema',
+    'channels',
 ]
 
 REST_FRAMEWORK = {
@@ -175,6 +176,7 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'apps.wsgi.application'
+ASGI_APPLICATION = 'apps.routing.application'
 
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = 'test-results/unittest/results.xml'

--- a/conf/test_settings.py
+++ b/conf/test_settings.py
@@ -1,3 +1,6 @@
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
 from conf import *
 
 ENVIRONMENT = 'TEST'
@@ -17,3 +20,6 @@ for name, logger in LOGGING['loggers'].items():
     logger['handlers'] = [h for h in logger.get('handlers', []) if h != 'elasticsearch']
     if logger.get('level') == 'DEBUG':
         logger['level'] = 'INFO'
+
+JWT_AUTH['JWT_PRIVATE_KEY'] = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+JWT_AUTH['JWT_PUBLIC_KEY'] = JWT_AUTH['JWT_PRIVATE_KEY'].public_key()

--- a/conf/test_settings.py
+++ b/conf/test_settings.py
@@ -1,4 +1,4 @@
-from . import *
+from conf import *
 
 ENVIRONMENT = 'TEST'
 INFLUXDB_DISABLED = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = conf/test_settings
+# -- recommended but optional:
+python_files = tests.py test_*.py *_tests.py
+addopts = -p no:warnings

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -103,7 +103,7 @@ async def test_jwt_refresh():
     await communicator.send_json_to({"event": "refresh_jwt", "data": my_jwt})
     await communicator.send_json_to({"hello": "world"})
     response = await communicator.receive_json_from()
-    assert response['event'] == str(EventTypes.error)
+    assert response['event'] == EventTypes.error.name
     assert response['data'] == "This websocket endpoint is read-only"
 
     await communicator.disconnect()
@@ -137,7 +137,7 @@ async def test_job_notification(communicator):
             await sync_to_async(job.message_set.create)(type=MessageType.ETH_TRANSACTION, body=json.dumps({'foo': 'bar'}))
             assert job.joblistener_set.count() == 1
             response = await communicator.receive_json_from()
-            assert response['event'] == str(EventTypes.asyncjob_update)
+            assert response['event'] == EventTypes.asyncjob_update.name
             assert response['data']['id'] == job.id
 
     await communicator.disconnect()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -135,3 +135,5 @@ async def test_job_notification(communicator):
             assert job.joblistener_set.count() == 1
             response = await communicator.receive_json_from()
             assert response['id'] == job.id
+
+    await communicator.disconnect()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,137 @@
+"""
+Copyright 2018 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+
+import jwt
+import pytest
+from asgiref.sync import sync_to_async
+from channels.testing import WebsocketCommunicator
+from django.conf import settings
+from django.db import models
+from django_mock_queries.mocks import mocked_relations
+from mock import patch
+
+from apps.jobs.models import AsyncJob, JobListener, MessageType
+from apps.routing import application
+
+USER_ID = '00000000-0000-0000-0000-000000000000'
+
+
+async def get_jwt(exp=None, sub=USER_ID):
+    payload = {'email': 'fake@shipchain.io', 'username': 'fake@shipchain.io', 'sub': sub,
+                        'aud': settings.JWT_AUTH['JWT_AUDIENCE']}
+    if exp:
+        payload['exp'] = exp
+
+    return jwt.encode(payload=payload, key=settings.JWT_AUTH['JWT_PRIVATE_KEY'],
+                      algorithm='RS256',
+                      headers={'kid': '230498151c214b788dd97f22b85410a5'}).decode()
+
+
+async def get_communicator(my_jwt):
+    return WebsocketCommunicator(application, f"ws/{USER_ID}/notifications",
+                                 subprotocols=[f"base64.jwt.{my_jwt}", "base64.authentication.jwt"])
+
+
+@pytest.fixture
+async def communicator():
+    communicator = await get_communicator(await get_jwt())
+    connected, subprotocol = await communicator.connect()
+    assert connected
+    assert subprotocol == "base64.authentication.jwt"
+    assert communicator.receive_nothing()
+    return communicator
+
+
+@pytest.mark.asyncio
+async def test_jwt_auth():
+    # Expired JWT
+    expired_jwt = await get_jwt(exp='1')
+    communicator = await get_communicator(expired_jwt)
+    connected, subprotocol = await communicator.connect()
+    assert not connected
+    assert subprotocol == 1000
+    await communicator.disconnect()
+
+    # User ID in token doesn't match route
+    unauthorized_jwt = await get_jwt(sub='4686c616-fadf-4261-a2c2-6aaa504a1ae4')
+    communicator = await get_communicator(unauthorized_jwt)
+    connected, subprotocol = await communicator.connect()
+    assert not connected
+    assert subprotocol == 1000
+    await communicator.disconnect()
+
+    # Invalid protocols
+    valid_jwt = await get_jwt()
+    communicator = WebsocketCommunicator(application, f"ws/{USER_ID}/notifications",
+                                         subprotocols=[f"base64.wat.{valid_jwt}", "base64.authentication.wat"])
+    connected, subprotocol = await communicator.connect()
+    assert not connected
+    assert subprotocol == 1000
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_jwt_refresh():
+    my_jwt = await get_jwt()
+    communicator = await get_communicator(my_jwt)
+
+    expired_jwt = await get_jwt(exp='1')
+    await communicator.send_to(text_data=json.dumps({"event": "refresh_jwt", "data": expired_jwt}))
+
+    await communicator.send_to(json.dumps({"hello": "world"}))
+    await communicator.receive_nothing()  # Socket should be closed due to expired jwt
+    await communicator.disconnect()
+
+    # TODO: Try to find a way to get freezegun to work with django channels to properly test token expiration
+
+    communicator = await get_communicator(my_jwt)
+    await communicator.send_json_to({"event": "refresh_jwt", "data": my_jwt})
+    await communicator.send_json_to({"hello": "world"})
+    await communicator.receive_from()
+
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_job_notification(communicator):
+    class DummyRPCClient:
+        def do_whatever(self):
+            pass
+
+    class DummyListener(models.Model):
+        id = models.CharField(primary_key=True, max_length=36)
+        owner_id = models.CharField(null=False, max_length=36)
+
+        class Meta:
+            app_label = 'apps.jobs'
+
+    listener = DummyListener(id='FAKE_LISTENER_ID', owner_id=USER_ID)
+
+    with mocked_relations(JobListener):
+        job = await sync_to_async(AsyncJob.rpc_job_for_listener)(rpc_method=DummyRPCClient.do_whatever, rpc_parameters=[],
+                                                                 signing_wallet_id='FAKE_WALLET_ID', listener=listener)
+        from django_mock_queries.query import MockSet, Mock
+        from django_mock_queries.mocks import MockOneToManyMap
+
+        with patch.object(AsyncJob, 'joblistener_set', MockOneToManyMap(AsyncJob.joblistener_set)):
+            job.joblistener_set = MockSet(Mock(listener=listener))
+
+            await sync_to_async(job.message_set.create)(type=MessageType.ETH_TRANSACTION, body=json.dumps({'foo': 'bar'}))
+            assert job.joblistener_set.count() == 1
+            response = await communicator.receive_json_from()
+            assert response['id'] == job.id


### PR DESCRIPTION
A number of changes needed to be made in order to support websocket notifications for asynchronous jobs.

- Django channels was added to the project
- A passive JWT auth scheme was implemented using the websocket 'subprotocols' header.
- Unit test runner was changed to pytest for asyncio test support
- A websocket endpoint was added for user notifications
- User notifications are triggered when an AsyncJob transaction is complete
- Websocket message format is like `{"event": "event_type_enum", "data": "payload of event"}`
- Made required Nginx changes to support deploying the app to our infra
- Fixed /jobs/ REST view (did not scope data down by user ID)