### PR TITLE
Check if profiles_url is disabled rather than exists

### DIFF
--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -80,12 +80,13 @@ class TransactionViewSet(mixins.RetrieveModelMixin,
     """
     queryset = EthAction.objects.all()
     serializer_class = EthActionSerializer
-    permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL else (permissions.AllowAny,)
+    permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL != 'DISABLED'\
+        else (permissions.AllowAny,)
 
     def get_queryset(self):
         log_metric('transmission.info', tags={'method': 'transaction.get_queryset', 'module': __name__})
         LOG.debug('Getting tx details for a transaction hash.')
         queryset = self.queryset
-        if settings.PROFILES_URL:
+        if settings.PROFILES_URL != 'DISABLED':
             queryset = queryset.filter(ethlistener__shipments__owner_id=self.request.user.id)
         return queryset

--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -80,13 +80,13 @@ class TransactionViewSet(mixins.RetrieveModelMixin,
     """
     queryset = EthAction.objects.all()
     serializer_class = EthActionSerializer
-    permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL != 'DISABLED'\
-        else (permissions.AllowAny,)
+    permission_classes = ((permissions.IsAuthenticated, IsOwner) if settings.PROFILES_ENABLED
+                          else (permissions.AllowAny,))
 
     def get_queryset(self):
         log_metric('transmission.info', tags={'method': 'transaction.get_queryset', 'module': __name__})
         LOG.debug('Getting tx details for a transaction hash.')
         queryset = self.queryset
-        if settings.PROFILES_URL != 'DISABLED':
+        if settings.PROFILES_ENABLED:
             queryset = queryset.filter(ethlistener__shipments__owner_id=self.request.user.id)
         return queryset

--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -105,7 +105,7 @@ class Device(models.Model):
     @staticmethod
     def get_or_create_with_permission(jwt, device_id):
         certificate_id = None
-        if settings.PROFILES_URL:
+        if settings.PROFILES_URL != 'DISABLED':
             # Make a request to Profiles /api/v1/devices/{device_id} with the user's JWT
             response = settings.REQUESTS_SESSION.get(f'{settings.PROFILES_URL}/api/v1/device/{device_id}/',
                                                      headers={'Authorization': 'JWT {}'.format(jwt.decode())})

--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -105,7 +105,7 @@ class Device(models.Model):
     @staticmethod
     def get_or_create_with_permission(jwt, device_id):
         certificate_id = None
-        if settings.PROFILES_URL != 'DISABLED':
+        if settings.PROFILES_ENABLED:
             # Make a request to Profiles /api/v1/devices/{device_id} with the user's JWT
             response = settings.REQUESTS_SESSION.get(f'{settings.PROFILES_URL}/api/v1/device/{device_id}/',
                                                      headers={'Authorization': 'JWT {}'.format(jwt.decode())})

--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -60,7 +60,7 @@ class LocationSerializer(NullableFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = Location
         fields = '__all__'
-        read_only_fields = ('owner_id',) if settings.PROFILES_URL != 'DISABLED' else ()
+        read_only_fields = ('owner_id',) if settings.PROFILES_ENABLED else ()
 
 
 class LocationVaultSerializer(NullableFieldsMixin, serializers.ModelSerializer):
@@ -70,7 +70,7 @@ class LocationVaultSerializer(NullableFieldsMixin, serializers.ModelSerializer):
 
     class Meta:
         model = Location
-        exclude = ('owner_id', 'geometry') if settings.PROFILES_URL != 'DISABLED' else ('geometry')
+        exclude = ('owner_id', 'geometry') if settings.PROFILES_ENABLED else ('geometry')
 
 
 class LoadShipmentSerializer(NullableFieldsMixin, serializers.ModelSerializer):
@@ -103,8 +103,7 @@ class ShipmentSerializer(serializers.ModelSerializer, EnumSupportSerializerMixin
     class Meta:
         model = Shipment
         fields = '__all__'
-        read_only_fields = ('owner_id', 'contract_version') if settings.PROFILES_URL != 'DISABLED'\
-            else ('contract_version',)
+        read_only_fields = ('owner_id', 'contract_version') if settings.PROFILES_ENABLED else ('contract_version',)
 
     class JSONAPIMeta:
         included_resources = ['ship_from_location', 'ship_to_location',
@@ -133,8 +132,7 @@ class ShipmentCreateSerializer(ShipmentSerializer):
             return Shipment.objects.create(**validated_data, **extra_args)
 
     def validate_shipper_wallet_id(self, shipper_wallet_id):
-        print(settings.PROFILES_URL)
-        if settings.PROFILES_URL != 'DISABLED':
+        if settings.PROFILES_ENABLED:
             auth = self.context['auth']
             response = settings.REQUESTS_SESSION.get(f'{settings.PROFILES_URL}/api/v1/wallet/{shipper_wallet_id}/',
                                                      headers={'Authorization': 'JWT {}'.format(auth.decode())})
@@ -151,7 +149,7 @@ class ShipmentUpdateSerializer(ShipmentSerializer):
     class Meta:
         model = Shipment
         fields = '__all__'
-        if settings.PROFILES_URL != 'DISABLED':
+        if settings.PROFILES_ENABLED:
             read_only_fields = ('owner_id', 'vault_id', 'shipper_wallet_id', 'carrier_wallet_id',
                                 'storage_credentials_id', 'contract_version')
         else:

--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -133,6 +133,7 @@ class ShipmentCreateSerializer(ShipmentSerializer):
             return Shipment.objects.create(**validated_data, **extra_args)
 
     def validate_shipper_wallet_id(self, shipper_wallet_id):
+        print(settings.PROFILES_URL)
         if settings.PROFILES_URL != 'DISABLED':
             auth = self.context['auth']
             response = settings.REQUESTS_SESSION.get(f'{settings.PROFILES_URL}/api/v1/wallet/{shipper_wallet_id}/',

--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -60,7 +60,7 @@ class LocationSerializer(NullableFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = Location
         fields = '__all__'
-        read_only_fields = ('owner_id',) if settings.PROFILES_URL else ()
+        read_only_fields = ('owner_id',) if settings.PROFILES_URL != 'DISABLED' else ()
 
 
 class LocationVaultSerializer(NullableFieldsMixin, serializers.ModelSerializer):
@@ -70,7 +70,7 @@ class LocationVaultSerializer(NullableFieldsMixin, serializers.ModelSerializer):
 
     class Meta:
         model = Location
-        exclude = ('owner_id', 'geometry') if settings.PROFILES_URL else ('geometry')
+        exclude = ('owner_id', 'geometry') if settings.PROFILES_URL != 'DISABLED' else ('geometry')
 
 
 class LoadShipmentSerializer(NullableFieldsMixin, serializers.ModelSerializer):
@@ -103,7 +103,8 @@ class ShipmentSerializer(serializers.ModelSerializer, EnumSupportSerializerMixin
     class Meta:
         model = Shipment
         fields = '__all__'
-        read_only_fields = ('owner_id', 'contract_version') if settings.PROFILES_URL else ('contract_version',)
+        read_only_fields = ('owner_id', 'contract_version') if settings.PROFILES_URL != 'DISABLED'\
+            else ('contract_version',)
 
     class JSONAPIMeta:
         included_resources = ['ship_from_location', 'ship_to_location',
@@ -132,7 +133,7 @@ class ShipmentCreateSerializer(ShipmentSerializer):
             return Shipment.objects.create(**validated_data, **extra_args)
 
     def validate_shipper_wallet_id(self, shipper_wallet_id):
-        if settings.PROFILES_URL:
+        if settings.PROFILES_URL != 'DISABLED':
             auth = self.context['auth']
             response = settings.REQUESTS_SESSION.get(f'{settings.PROFILES_URL}/api/v1/wallet/{shipper_wallet_id}/',
                                                      headers={'Authorization': 'JWT {}'.format(auth.decode())})
@@ -149,7 +150,7 @@ class ShipmentUpdateSerializer(ShipmentSerializer):
     class Meta:
         model = Shipment
         fields = '__all__'
-        if settings.PROFILES_URL:
+        if settings.PROFILES_URL != 'DISABLED':
             read_only_fields = ('owner_id', 'vault_id', 'shipper_wallet_id', 'carrier_wallet_id',
                                 'storage_credentials_id', 'contract_version')
         else:

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -20,18 +20,18 @@ LOG = logging.getLogger('transmission')
 class ShipmentViewSet(viewsets.ModelViewSet):
     queryset = Shipment.objects.all()
     serializer_class = ShipmentSerializer
-    permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL != 'DISABLED'\
-        else (permissions.AllowAny,)
+    permission_classes = ((permissions.IsAuthenticated, IsOwner) if settings.PROFILES_ENABLED
+                          else (permissions.AllowAny,))
     http_method_names = ['get', 'post', 'delete', 'patch']
 
     def get_queryset(self):
         queryset = self.queryset
-        if settings.PROFILES_URL != 'DISABLED':
+        if settings.PROFILES_ENABLED:
             queryset = queryset.filter(owner_id=self.request.user.id)
         return queryset
 
     def perform_create(self, serializer):
-        if settings.PROFILES_URL != 'DISABLED':
+        if settings.PROFILES_ENABLED:
             created = serializer.save(owner_id=self.request.user.id)
         else:
             created = serializer.save()
@@ -143,18 +143,18 @@ class LocationViewSet(viewsets.ModelViewSet):
     queryset = Location.objects.all()
     serializer_class = LocationSerializer
     # TODO: Clarify/Solidify the permissions for Locations w/ respect to owner_id
-    permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL != 'DISABLED'\
-        else (permissions.AllowAny,)
+    permission_classes = ((permissions.IsAuthenticated, IsOwner) if settings.PROFILES_ENABLED
+                          else (permissions.AllowAny,))
     http_method_names = ['get', 'post', 'delete', 'patch']
 
     def get_queryset(self):
         queryset = self.queryset
-        if settings.PROFILES_URL != 'DISABLED':
+        if settings.PROFILES_ENABLED:
             queryset = queryset.filter(owner_id=self.request.user.id)
         return queryset
 
     def perform_create(self, serializer):
-        if settings.PROFILES_URL != 'DISABLED':
+        if settings.PROFILES_ENABLED:
             created = serializer.save(owner_id=self.request.user.id)
         else:
             created = serializer.save()

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -20,17 +20,18 @@ LOG = logging.getLogger('transmission')
 class ShipmentViewSet(viewsets.ModelViewSet):
     queryset = Shipment.objects.all()
     serializer_class = ShipmentSerializer
-    permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL else (permissions.AllowAny,)
+    permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL != 'DISABLED'\
+        else (permissions.AllowAny,)
     http_method_names = ['get', 'post', 'delete', 'patch']
 
     def get_queryset(self):
         queryset = self.queryset
-        if settings.PROFILES_URL:
+        if settings.PROFILES_URL != 'DISABLED':
             queryset = queryset.filter(owner_id=self.request.user.id)
         return queryset
 
     def perform_create(self, serializer):
-        if settings.PROFILES_URL:
+        if settings.PROFILES_URL != 'DISABLED':
             created = serializer.save(owner_id=self.request.user.id)
         else:
             created = serializer.save()
@@ -142,17 +143,18 @@ class LocationViewSet(viewsets.ModelViewSet):
     queryset = Location.objects.all()
     serializer_class = LocationSerializer
     # TODO: Clarify/Solidify the permissions for Locations w/ respect to owner_id
-    permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL else (permissions.AllowAny,)
+    permission_classes = (permissions.IsAuthenticated, IsOwner) if settings.PROFILES_URL != 'DISABLED'\
+        else (permissions.AllowAny,)
     http_method_names = ['get', 'post', 'delete', 'patch']
 
     def get_queryset(self):
         queryset = self.queryset
-        if settings.PROFILES_URL:
+        if settings.PROFILES_URL != 'DISABLED':
             queryset = queryset.filter(owner_id=self.request.user.id)
         return queryset
 
     def perform_create(self, serializer):
-        if settings.PROFILES_URL:
+        if settings.PROFILES_URL != 'DISABLED':
             created = serializer.save(owner_id=self.request.user.id)
         else:
             created = serializer.save()

--- a/conf/base.py
+++ b/conf/base.py
@@ -26,9 +26,11 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ENGINE_RPC_URL = os.environ.get('ENGINE_RPC_URL', "http://engine-rpc:2000/")
 INTERNAL_URL = os.environ.get('INTERNAL_URL', 'http://transmission-runserver:8000')
 PROFILES_URL = os.environ.get('PROFILES_URL')
+PROFILES_ENABLED = PROFILES_URL != 'DISABLED'
 if PROFILES_URL != 'DISABLED':
     PROFILES_URL = ('http://profiles-runserver:8000' if ('runserver' in INTERNAL_URL)
                     else INTERNAL_URL.replace("transmission", "profiles"))
+
 ELASTICSEARCH_URL = os.environ.get('ELASTICSEARCH_URL', None)
 
 ENVIRONMENT = os.environ.get('ENV', 'LOCAL')

--- a/tests/test_shipments.py
+++ b/tests/test_shipments.py
@@ -281,7 +281,7 @@ class ShipmentAPITests(APITestCase):
         post_data = replace_variables_in_string(post_data, parameters)
 
         httpretty.register_uri(httpretty.GET,
-                               f"http://INTENTIONALLY_DISCONNECTED:9999/api/v1/wallet/{parameters['_shipper_wallet_id']}/",
+                               f"{test_settings.PROFILES_URL}/api/v1/wallet/{parameters['_shipper_wallet_id']}/",
                                body=json.dumps({'good': 'good'}), status=status.HTTP_200_OK)
 
         response = self.client.post(url, post_data, content_type='application/vnd.api+json')
@@ -295,6 +295,7 @@ class ShipmentAPITests(APITestCase):
         self.assertEqual(response_data['attributes']['vault_id'], parameters['_vault_id'])
         self.assertIsNotNone(response_data['meta']['async_job_id'])
 
+        previous_profiles_url = test_settings.PROFILES_URL
         test_settings.PROFILES_URL = 'DISABLED'
 
         httpretty.register_uri(httpretty.GET,
@@ -304,7 +305,7 @@ class ShipmentAPITests(APITestCase):
         response = self.client.post(url, post_data, content_type='application/vnd.api+json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
-        test_settings.PROFILES_URL = 'http://INTENTIONALLY_DISCONNECTED:9999'
+        test_settings.PROFILES_URL = previous_profiles_url
 
 
 
@@ -380,7 +381,7 @@ class ShipmentAPITests(APITestCase):
         httpretty.register_uri(httpretty.GET, google_url, body=json.dumps(google_obj))
         httpretty.register_uri(httpretty.GET, mapbox_url, body=json.dumps(mapbox_obj))
         httpretty.register_uri(httpretty.GET,
-                               f"http://INTENTIONALLY_DISCONNECTED:9999/api/v1/wallet/{parameters['_shipper_wallet_id']}/",
+                               f"{test_settings.PROFILES_URL}/api/v1/wallet/{parameters['_shipper_wallet_id']}/",
                                body=json.dumps({'good': 'good'}), status=status.HTTP_200_OK)
 
         # Authenticated request should succeed using mapbox (if exists)
@@ -492,7 +493,7 @@ class ShipmentAPITests(APITestCase):
         self.assertEqual(ship_to_location.name, parameters['_ship_to_location_name'])
         self.assertEqual(ship_to_location.geometry.coords, (12.0, 23.0))
 
-
+        previous_profiles_url = test_settings.PROFILES_URL
         test_settings.PROFILES_URL = 'DISABLED'
         httpretty.register_uri(httpretty.GET,
                                f"{test_settings.PROFILES_URL}/api/v1/wallet/{parameters['_shipper_wallet_id']}/",
@@ -501,7 +502,7 @@ class ShipmentAPITests(APITestCase):
         response = self.client.post(url, one_location, content_type=content_type)
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
-        test_settings.PROFILES_URL = 'http://INTENTIONALLY_DISCONNECTED:9999'
+        test_settings.PROFILES_URL = previous_profiles_url
 
     def test_get_device_request_url(self):
 
@@ -512,7 +513,6 @@ class ShipmentAPITests(APITestCase):
         profiles_url = shipment.get_device_request_url()
 
         # http://INTENTIONALLY_DISCONNECTED:9999/api/v1/device/?on_shipment=b715a8ff-9299-4c87-96de-a4b0a4a54509
-        print(profiles_url)
         self.assertIn(test_settings.PROFILES_URL, profiles_url)
         self.assertIn(f"?on_shipment={_shipment_id}", profiles_url)
 


### PR DESCRIPTION
It is safer to ensure that when comparing against the PROFILES_URL in settings, that the url is set to disabled rather than if it exists. This allows greater control over calls using profiles_url.