### PR TITLE
Add page_size back in to the swagger

### DIFF
--- a/apps/schema/static/schema/swagger.yaml
+++ b/apps/schema/static/schema/swagger.yaml
@@ -431,6 +431,15 @@ components:
         type: integer
         format: int32
 
+    page_size:
+      name: page_size
+      in: query
+      description: Number of objects displayed per page
+      required: false
+      schema:
+        type: integer
+        format: int32
+
     search:
       name: search
       in: query


### PR DESCRIPTION
At the moment, swagger is down for transmission. This fixes it by re-adding the page_size to the swagger branch.