### PR TITLE
Prevent duplication of event data

### DIFF
--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -48,7 +48,7 @@ class EventViewSet(mixins.CreateModelMixin,
                 LOG.info(f"Non-EthAction Event processed "
                          f"Tx: {serializer.data['transaction_hash']}")
 
-            Event.objects.create(**serializer.data, eth_action=action)
+            Event.objects.get_or_create(**serializer.data, eth_action=action)
 
         else:
             LOG.debug('Events is_many is true')
@@ -66,7 +66,7 @@ class EventViewSet(mixins.CreateModelMixin,
                     LOG.info(f"Non-EthAction Event processed "
                              f"Tx: {event['transaction_hash']}")
 
-                Event.objects.create(**event, eth_action=action)
+                Event.objects.get_or_create(**event, eth_action=action)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/tests/profiles-enabled/test_events.py
+++ b/tests/profiles-enabled/test_events.py
@@ -1,0 +1,69 @@
+"""
+Copyright 2018 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from apps.eth.models import Event
+
+
+class EventTests(APITestCase):
+    def test_event_update(self):
+        url = reverse('event-list', kwargs={'version': 'v1'})
+        data = {
+            "address": "0x25Ff5dc79A7c4e34254ff0f4a19d69E491201DD3",
+            "blockNumber": 3,
+            "transactionHash": "0xc18a24a35052a5a3375ee6c2c5ddd6b0587cfa950b59468b67f63f284e2cc382",
+            "transactionIndex": 0,
+            "blockHash": "0x62469a8d113b27180c139d88a25f0348bb4939600011d33382b98e10842c85d9",
+            "logIndex": 0,
+            "removed": False,
+            "id": "log_25652065",
+            "returnValues": {
+              "0": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885",
+              "shipTokenContractAddress": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885"
+            },
+            "event": "SetTokenContractAddressEvent",
+            "signature": "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824",
+            "raw": {
+              "data": "0x000000000000000000000000fcaf25bf38e7c86612a25ff18cb8e09ab07c9885",
+              "topics": [
+                "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824"
+              ]
+            }
+          }
+        response = self.client.post(url, data, format='json')
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        # Set NGINX headers for engine auth
+        response = self.client.post(url, data, format='json', X_NGINX_SOURCE='internal',
+                                    X_SSL_CLIENT_VERIFY='SUCCESS', X_SSL_CLIENT_DN='/CN=engine.test-internal')
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        # Test idempotency of Events
+        num_events = Event.objects.count()
+        response = self.client.post(url, data, format='json', X_NGINX_SOURCE='internal',
+                                    X_SSL_CLIENT_VERIFY='SUCCESS', X_SSL_CLIENT_DN='/CN=engine.test-internal')
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert Event.objects.count() == num_events
+
+        response = self.client.post(url, [data, data], format='json', X_NGINX_SOURCE='internal',
+                                    X_SSL_CLIENT_VERIFY='SUCCESS', X_SSL_CLIENT_DN='/CN=engine.test-internal')
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert Event.objects.count() == num_events
+
+
+


### PR DESCRIPTION
If Engine re-sends event data to Transmission, a duplicate record will be saved. This change prevents duplicate event data from being saved to the Transmission database if Engine re-sends them.
_This currently only occurs in local testing_

- Use `get_or_create` when creating `Event` objects
- Added unit tests for /api/v1/events/ endpoint, asserted idempotency of requests