### PR TITLE
Feature transitioned local db to kartoza postgis

### DIFF
--- a/compose/circleci.yml
+++ b/compose/circleci.yml
@@ -19,9 +19,11 @@ services:
     networks:
       - portal
     environment:
-      POSTGRES_USER: transmission
-      POSTGRES_PASSWORD: transmission
-      POSTGRES_DB: transmission
+      - POSTGRES_USER=transmission
+      - POSTGRES_PASS=transmission
+      - POSTGRES_HOST=psql
+      - POSTGRES_DBNAME=transmission
+      - ALLOW_IP_RANGE=0.0.0.0/0
 
   runserver:
     extends:

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -11,13 +11,15 @@ services:
       --requirepass redis_pass --appendonly yes
 
   psql:
-    image: mdillon/postgis:9.6
     ports:
-    - "5432:5432"
+      - "5432:5432"
+    image: kartoza/postgis:9.6-2.4
     environment:
-      POSTGRES_USER: transmission
-      POSTGRES_PASSWORD: transmission
-      POSTGRES_DB: transmission
+      - POSTGRES_USER=transmission
+      - POSTGRES_PASS=transmission
+      - POSTGRES_HOST=psql
+      - POSTGRES_DBNAME=transmission
+      - ALLOW_IP_RANGE=0.0.0.0/0
     volumes:
       - /data/shipchain/transmission/postgresql:/var/lib/postgresql
 


### PR DESCRIPTION
- The local postgres database was not persisting when the docker-compose environment was restarted

- Upgraded local db to use kartoza/postgis instead of mdillion/postgis

- Integrated kartoza/postgis environment variable to `compose/circleci.yml`