### PR TITLE
Feature/document patch to return presigned url

### DIFF
--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -94,3 +94,15 @@ class DocumentRetrieveSerializer(DocumentSerializer):
         log_metric('transmission.info', tags={'method': 'documents.generate_presigned_url', 'module': __name__})
 
         return url
+
+
+class DocumentUpdateSerializer(DocumentRetrieveSerializer):
+
+    class Meta:
+        model = Document
+        exclude = ('shipment',)
+        if settings.PROFILES_ENABLED:
+            read_only_fields = ('owner_id', 'document_type', 'file_type', 'name', 'description')
+        else:
+            read_only_fields = ('document_type', 'file_type',)
+        meta_fields = ('presigned_s3',)

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -10,6 +10,7 @@ from .permissions import UserHasPermission
 
 from .serializers import (DocumentSerializer,
                           DocumentCreateSerializer,
+                          DocumentUpdateSerializer,
                           DocumentRetrieveSerializer,)
 from .models import Document
 from .filters import DocumentFilterSet
@@ -54,6 +55,23 @@ class DocumentViewSet(mixins.CreateModelMixin,
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+    def update(self, request, *args, **kwargs):
+        """
+        Update document object status according to upload status: COMPLETE or FAILED
+        """
+        partial = kwargs.pop('partial', False)
+        instance = self.get_object()
+        LOG.debug(f'Updating document {instance.id} with new details.')
+        log_metric('transmission.info', tags={'method': 'documents.update', 'module': __name__})
+
+        serializer = DocumentUpdateSerializer(instance, data=request.data, partial=partial,
+                                              context={'auth': request.auth})
+        serializer.is_valid(raise_exception=True)
+
+        self.perform_update(serializer)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()

--- a/tests/profiles-enabled/test_documents.py
+++ b/tests/profiles-enabled/test_documents.py
@@ -189,8 +189,10 @@ class PdfDocumentViewSetAPITests(APITestCase):
             'upload_status': UploadStatus.COMPLETE,
         })
         response = self.client.patch(url, file_data, content_type=content_type)
+        data = response.json()['data']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(document[1].upload_status, UploadStatus.COMPLETE)
+        self.assertTrue(data['meta']['presigned_s3'])
 
         # Get list of documents
         url = reverse('document-list', kwargs={'version': 'v1'})
@@ -357,6 +359,7 @@ class ImageDocumentViewSetAPITests(APITestCase):
         response = self.client.patch(url, file_data, content_type=content_type)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(document[0].upload_status, UploadStatus.COMPLETE)
+        self.assertTrue(data['meta']['presigned_s3'])
 
         # Get a document
         url = reverse('document-detail', kwargs={'version': 'v1', 'pk': document[0].id})

--- a/tests/profiles-enabled/test_documents.py
+++ b/tests/profiles-enabled/test_documents.py
@@ -215,6 +215,22 @@ class PdfDocumentViewSetAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data), 0)
 
+        # Get list of BOL documents via query params, it should return 2 elements
+        url = reverse('document-list', kwargs={'version': 'v1'})
+        url += f'?document_type=Bol'
+        response = self.client.get(url)
+        data = response.json()['data']
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data), 2)
+
+        # Querying for file objects with upload_status FAILED, should return an empty list at this stage
+        url = reverse('document-list', kwargs={'version': 'v1'})
+        url += f'?upload_status=FAIled'
+        response = self.client.get(url)
+        data = response.json()['data']
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data), 0)
+
         # List of all documents attached to a shipment
         url = reverse('shipment-documents-list', kwargs={'version': 'v1', 'shipment_pk': self.shipment.id})
         response = self.client.get(url)


### PR DESCRIPTION
- Overrode `update` method in `DocumentViewSet` to return presinged_s3 url
- Added custom serializer: `DocumentUpdateSerializer` to allow patch of only field: `upload_status`
- Added unit tests.