### PR TITLE
Hotfix: Fix circleci build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.8
+      - image: circleci/python@sha256:415aecafc0bde92a37b6b7f6a5b2c9082c23e9073eb90f8158665dabbf8eedf1
         user: root
     environment:
       ROLE: circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python@sha256:415aecafc0bde92a37b6b7f6a5b2c9082c23e9073eb90f8158665dabbf8eedf1
+      - image: circleci/python:3.6.8
         user: root
     environment:
       ROLE: circleci
@@ -21,8 +21,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - virtualenv-alpine-cache-{{ checksum "poetry.lock" }}
-            - virtualenv-alpine-cache
+            - virtualenv-alpine-cache-v2-{{ checksum "poetry.lock" }}
+            - virtualenv-alpine-cache-v2
 
       - run:
           name: Build Docker images
@@ -82,10 +82,10 @@ jobs:
       - run:
           name: Copy virtualenv cache from Docker
           command: |
-            docker cp $(bin/dc ps -q runserver):/app/.virtualenv .virtualenv
+            docker cp $(bin/dc ps -q runserver):/app/.virtualenv/. .virtualenv
 
       - save_cache:
-          key: virtualenv-alpine-cache-{{ checksum "poetry.lock" }}
+          key: virtualenv-alpine-cache-v2-{{ checksum "poetry.lock" }}
           paths:
             - .virtualenv
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,11 @@
 .dockerignore
 Dockerfile*
 db.sqlite3
-__pycache__
-.pytest_cache
-*.pyc
-*.pyo
-*.pyd
+**/__pycache__
+**/.pytest_cache
+**/*.pyc
+**/*.pyo
+**/*.pyd
 .Python
 env
 venv


### PR DESCRIPTION
Transmission's circleci config currently has an issue where it recursively copies the virtualenv cache into itself, leading to a ballooning Docker 'build context' size, and long build times.

This PR fixes this issue and invalidates old caches to avoid this issue.