### PR TITLE
Thumbnail Link serializer

### DIFF
--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -110,9 +110,9 @@ class DocumentRetrieveSerializer(DocumentSerializer):
 
     def get_presigned_s3_thumbnail(self, obj):
         if obj.upload_status != UploadStatus.COMPLETE:
-            return super().get_presigned_s3(obj)
+            return None
 
-        thumbnail_key = obj.s3_key[:-4] + '-t.jpg'
+        thumbnail_key = obj.s3_key.rsplit('.', 1)[0] + '-t.jpg'
 
         url = settings.S3_CLIENT.generate_presigned_url(
             'get_object',

--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -112,7 +112,7 @@ class DocumentRetrieveSerializer(DocumentSerializer):
         if obj.upload_status != UploadStatus.COMPLETE:
             return None
 
-        thumbnail_key = obj.s3_key.rsplit('.', 1)[0] + '-t.jpg'
+        thumbnail_key = obj.s3_key.rsplit('.', 1)[0] + '-t.png'
 
         url = settings.S3_CLIENT.generate_presigned_url(
             'get_object',

--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -70,6 +70,7 @@ class DocumentCreateSerializer(DocumentSerializer):
 
 
 class DocumentRetrieveSerializer(DocumentSerializer):
+    presigned_s3_thumbnail = serializers.SerializerMethodField()
 
     class Meta:
         model = Document
@@ -78,7 +79,7 @@ class DocumentRetrieveSerializer(DocumentSerializer):
             read_only_fields = ('owner_id', 'document_type', 'file_type',)
         else:
             read_only_fields = ('document_type', 'file_type',)
-        meta_fields = ('presigned_s3',)
+        meta_fields = ('presigned_s3', 'presigned_s3_thumbnail',)
 
     def get_presigned_s3(self, obj):
         if obj.upload_status != UploadStatus.COMPLETE:
@@ -104,5 +105,26 @@ class DocumentRetrieveSerializer(DocumentSerializer):
 
         LOG.debug(f'Generated one time s3 url for: {obj.id}')
         log_metric('transmission.info', tags={'method': 'documents.generate_presigned_url', 'module': __name__})
+
+        return url
+
+    def get_presigned_s3_thumbnail(self, obj):
+        if obj.upload_status != UploadStatus.COMPLETE:
+            return super().get_presigned_s3(obj)
+
+        thumbnail_key = obj.s3_key[:-4] + '-t.' + obj.file_type.name.lower()
+
+        url = settings.S3_CLIENT.generate_presigned_url(
+            'get_object',
+            Params={
+                'Bucket': f"{settings.S3_BUCKET}",
+                'Key': thumbnail_key
+            },
+            ExpiresIn=settings.S3_URL_LIFE
+        )
+
+        LOG.debug(f'Generated one time s3 url thumbnail for: {obj.id}')
+        log_metric('transmission.info', tags={'method': 'documents.generate_presigned_s3_thumbnail',
+                                              'module': __name__})
 
         return url

--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -112,7 +112,7 @@ class DocumentRetrieveSerializer(DocumentSerializer):
         if obj.upload_status != UploadStatus.COMPLETE:
             return super().get_presigned_s3(obj)
 
-        thumbnail_key = obj.s3_key[:-4] + '-t.' + obj.file_type.name.lower()
+        thumbnail_key = obj.s3_key[:-4] + '-t.jpg'
 
         url = settings.S3_CLIENT.generate_presigned_url(
             'get_object',


### PR DESCRIPTION
When storing a document, it can be helpful to show the thumbnail for the document. This will be automatically generated when the file is uploaded to the s3 bucket, and this function will allow the user to easily grab the thumbnail jpg upon uploading the file.