### PR TITLE
Feature get/refresh device certificate

### DIFF
--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -131,11 +131,11 @@ class Device(models.Model):
     @staticmethod
     def get_valid_certificate(device_id):
         certificate_id = None
-        iot = boto3.client('iot')
+        iot = boto3.client('iot', region_name='us-east-1')
 
         try:
             response = iot.list_thing_principals(thingName=device_id)
-            if not response['principals']:
+            if not len(response['principals']) > 0:  # pylint:disable=len-as-condition
                 raise PermissionDenied(f"No certificates found for device {device_id} in AWS IoT")
             for arn in response['principals']:
                 # arn == arn:aws:iot:us-east-1:489745816517:cert/{certificate_id}

--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -116,16 +116,15 @@ class Device(models.Model):
             if response.status_code != HTTP_200_OK:
                 raise PermissionDenied("User does not have access to this device in ShipChain Profiles")
 
+        device, created = Device.objects.get_or_create(id=device_id, defaults={'certificate_id': certificate_id})
+
         if settings.ENVIRONMENT != 'LOCAL':
             # We update the related device with this certificate in case it exists
-            device, created = Device.objects.get_or_create(id=device_id, defaults={'certificate_id': certificate_id})
-
             if not created:
                 device.certificate_id = Device.get_valid_certificate(device_id)
                 device.save()
-                return device
 
-        return Device.objects.get_or_create(id=device_id, defaults={'certificate_id': certificate_id})
+        return device
 
     @staticmethod
     def get_valid_certificate(device_id):

--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -7,6 +7,7 @@ import geocoder
 from geocoder.keys import mapbox_access_token
 
 import boto3
+from botocore.exceptions import ClientError
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
@@ -116,19 +117,45 @@ class Device(models.Model):
                 raise PermissionDenied("User does not have access to this device in ShipChain Profiles")
 
         if settings.ENVIRONMENT != 'LOCAL':
-            iot = boto3.client('iot')
-
+            certificate_id = Device.get_valid_certificate(device_id)
+            # We update the related device with this certificate in case it exists
             try:
-                response = iot.list_thing_principals(thingName=device_id)
-                if not response['principals']:
-                    raise PermissionDenied(f"No certificates found for device {device_id} in AWS IoT")
-                for arn in response['principals']:
-                    # arn == arn:aws:iot:us-east-1:489745816517:cert/{certificate_id}
-                    certificate_id = arn.rsplit('/', 1)[1]
-                    break
-            except iot.exceptions.ResourceNotFoundException:
-                raise PermissionDenied(f"Specified device {device_id} does not exist in AWS IoT")
+                device = Device.objects.get(id=device_id)
+                device.certificate_id = certificate_id
+                device.save()
+            except Device.DoesNotExist:
+                pass
+
         return Device.objects.get_or_create(id=device_id, defaults={'certificate_id': certificate_id})[0]
+
+    @staticmethod
+    def get_valid_certificate(device_id):
+        certificate_id = None
+        iot = boto3.client('iot')
+
+        try:
+            response = iot.list_thing_principals(thingName=device_id)
+            if not response['principals']:
+                raise PermissionDenied(f"No certificates found for device {device_id} in AWS IoT")
+            for arn in response['principals']:
+                # arn == arn:aws:iot:us-east-1:489745816517:cert/{certificate_id}
+                certificate_id = arn.rsplit('/', 1)[1]
+                try:
+                    certificate = iot.describe_certificate(certificateId=certificate_id)
+                    if certificate['certificateDescription']['status'] != 'ACTIVE':
+                        certificate_id = None
+                    else:
+                        break
+                except ClientError as exc:
+                    LOG.debug(f"Encountered error: {exc}, while parsing certificate: {certificate_id}")
+
+        except iot.exceptions.ResourceNotFoundException:
+            raise PermissionDenied(f"Specified device {device_id} does not exist in AWS IoT")
+        except Exception as exception:
+            raise PermissionDenied(f"Unexpected error: {exception}, occurred while trying to retrieve device: "
+                                   f"{device_id}, from AWS IoT")
+
+        return certificate_id
 
 
 class FundingType(Enum):

--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -146,7 +146,7 @@ class Device(models.Model):
                     else:
                         break
                 except ClientError as exc:
-                    LOG.debug(f"Encountered error: {exc}, while parsing certificate: {certificate_id}")
+                    LOG.warning(f"Encountered error: {exc}, while parsing certificate: {certificate_id}")
 
         except iot.exceptions.ResourceNotFoundException:
             raise PermissionDenied(f"Specified device {device_id} does not exist in AWS IoT")

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import boto3
 import httpretty
+from botocore.stub import Stubber
 from datetime import datetime, timezone
 from dateutil import parser
 from django.conf import settings as test_settings
@@ -364,6 +365,143 @@ class ShipmentAPITests(APITestCase):
             self.shipments[0].save()
             response = self.client.post(url, {'payload': signed_data}, format='json')
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # @mock_iot
+    def test_update_shipment_device_certificate(self):
+        """
+        The shipment's device certificate has been updated but the the old certificate is still attached to the device.
+        when we post new tracking data, we should be able to track and retrieve the new certificate in aws IoT and
+        attach it to the device
+        """
+        from apps.rpc_client import requests
+        from tests.utils import mocked_rpc_response
+
+        with mock_iot():
+            iot = boto3.client('iot', region_name='us-east-1')
+
+            device_id = 'adfc1e4c-7e61-4aee-b6f5-4d8b95a7ec75'
+
+            with open('tests/data/cert.pem', 'r') as cert_file:
+                cert_pem = cert_file.read()
+
+            map_describe = {}
+            principals = []
+            expired_certificate = None
+            new_active_certificate = None
+            for i in range(0, 4):
+                describe = {}
+                res = iot.create_keys_and_certificate()
+                describe['certificateDescription'] = res
+                describe['certificateDescription']['status'] = 'INACTIVE'
+                if i == 1:
+                    expired_certificate = res['certificateId']
+                if i == 2:
+                    describe['certificateDescription']['status'] = 'ACTIVE'
+                    describe['certificateDescription']['certificatePem'] = cert_pem
+                    new_active_certificate = res['certificateId']
+                map_describe[res['certificateId']] = describe
+                principals.append(res['certificateArn'])
+
+        # Set device for Shipment
+        with mock.patch.object(requests.Session, 'post') as mock_method:
+            mock_method.return_value = mocked_rpc_response({
+                "jsonrpc": "2.0",
+                "result": {
+                    "success": True,
+                    "vault_id": "TEST_VAULT_ID"
+                }
+            })
+            self.create_shipment()
+            self.shipments[0].device = Device.objects.create(
+                id=device_id,
+                certificate_id=expired_certificate
+            )
+
+            mock_method.return_value = mocked_rpc_response({
+                "jsonrpc": "2.0",
+                "result": {
+                    "success": True,
+                    "vault_signed": {'hash': "TEST_VAULT_SIGNATURE"}
+                }
+            })
+            self.shipments[0].save()
+
+        url = reverse('shipment-tracking', kwargs={'version': 'v1', 'pk': self.shipments[0].id})
+
+        track_dic = {
+            'position': {
+                'latitude': 75.0587610,
+                'longitude': -35.628643,
+                'altitude': 554,
+                'source': 'Gps',
+                'uncertainty': 92,
+                'speed': 34
+            },
+            'version': '1.0.0',
+            'device_id': 'adfc1e4c-7e61-4aee-b6f5-4d8b95a7ec75',
+            'timestamp': '2018-09-18T15:02:30.563847+00:00'
+        }
+
+        def side_effects(**kwargs):
+            cert = kwargs['certificateId']
+            return map_describe[cert]
+
+        with mock.patch('apps.shipments.serializers.boto3.client') as serial_client, \
+                mock.patch('apps.shipments.models.boto3.client') as model_client:
+            serial_client = serial_client.return_value
+            model_client = model_client.return_value
+            serial_client.describe_certificate.side_effect = side_effects
+            model_client.list_thing_principals.return_value = {'principals': principals}
+            model_client.describe_certificate.side_effect = side_effects
+
+            with open('tests/data/eckey.pem', 'r') as key_file:
+                key_pem = key_file.read()
+            signed_data = jws.sign(track_dic, key=key_pem, headers={'kid': new_active_certificate}, algorithm='ES256')
+
+            # Send tracking data
+            response = self.client.post(url, {'payload': signed_data}, format='json')
+            self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+            # The new certificate should be attached to the shipment's device
+            device = self.shipments[0].device
+            device.refresh_from_db()
+            self.assertEqual(device.certificate_id, new_active_certificate)
+
+            # Creating a new shipment with a device for which the certificate has expired and a new one has been issued
+            self.shipments[0].device = None
+            self.shipments[0].save()
+            device.certificate_id = expired_certificate
+            device.save()
+            device.refresh_from_db()
+
+            post_data = {
+                'device_id': device.id,
+                'vault_id': VAULT_ID,
+                'carrier_wallet_id': CARRIER_WALLET_ID,
+                'shipper_wallet_id': SHIPPER_WALLET_ID,
+                'storage_credentials_id': STORAGE_CRED_ID
+            }
+
+            url = reverse('shipment-list', kwargs={'version': 'v1'})
+            self.set_user(self.user_1)
+
+            with mock.patch('apps.shipments.serializers.ShipmentCreateSerializer.validate_shipper_wallet_id') as mock_wallet_validation, \
+                    mock.patch('apps.shipments.serializers.ShipmentCreateSerializer.validate_storage_credentials_id') as mock_storage_validation, \
+                    mock.patch.object(requests.Session, 'get') as mock_method:
+
+                # Instead of httpretty, we mock the device's profile validation
+                mock_method.return_value.status_code = status.HTTP_200_OK
+
+                mock_wallet_validation.return_value = SHIPPER_WALLET_ID
+                mock_storage_validation.return_value = STORAGE_CRED_ID
+
+                response = self.client.post(url, post_data, format='json')
+                self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
+                # The new certificate should be attached to the shipment's device
+                device.refresh_from_db()
+                self.assertEqual(device.certificate_id, new_active_certificate)
+                data = response.json()['data']
+                self.assertEqual(device.shipment.id, data['id'])
 
     @httpretty.activate
     def test_create(self):

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import boto3
 import httpretty
-from botocore.stub import Stubber
 from datetime import datetime, timezone
 from dateutil import parser
 from django.conf import settings as test_settings
@@ -366,7 +365,6 @@ class ShipmentAPITests(APITestCase):
             response = self.client.post(url, {'payload': signed_data}, format='json')
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    # @mock_iot
     def test_update_shipment_device_certificate(self):
         """
         The shipment's device certificate has been updated but the the old certificate is still attached to the device.


### PR DESCRIPTION
With this PR we ensure that any time a new certificate is issued for a given device, it's retrieve in `Aws IoT` and cached in Txm via one of the two use cases:
- The device tries the post new tracking data
- The device is set up on a new shipment