### PR TITLE
Feature/document permission list

### DIFF
--- a/apps/documents/permissions.py
+++ b/apps/documents/permissions.py
@@ -17,8 +17,9 @@ class UserHasPermission(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         shipment = obj.shipment
 
-        return has_owner_access(request, obj) or self.is_shipper(request, shipment) or \
-            self.is_carrier(request, shipment) or self.is_moderator(request, shipment)
+        return has_owner_access(request, obj) or has_owner_access(request, shipment) or \
+            self.is_shipper(request, shipment) or self.is_carrier(request, shipment) or \
+            self.is_moderator(request, shipment)
 
     def has_permission(self, request, view):
 
@@ -26,7 +27,7 @@ class UserHasPermission(permissions.BasePermission):
         if not shipment_id:
             return True
 
-        shipment = Shipment.objects.filter(id=shipment_id).first()
+        shipment = Shipment.objects.get(id=shipment_id)
 
         return has_owner_access(request, shipment) or self.is_shipper(request, shipment) or \
             self.is_carrier(request, shipment) or self.is_moderator(request, shipment)

--- a/apps/documents/permissions.py
+++ b/apps/documents/permissions.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 from rest_framework import permissions, status
+
+from apps.shipments.models import Shipment
 from apps.authentication import get_jwt_from_request
 from apps.permissions import has_owner_access
 
@@ -13,32 +15,45 @@ class UserHasPermission(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj):
+        shipment = obj.shipment
 
-        def is_carrier():
-            """
-            Custom permission for carrier documents management access
-            """
-            response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{obj.shipment.carrier_wallet_id}/',
-                                                     headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+        return has_owner_access(request, obj) or self.is_shipper(request, shipment) or \
+            self.is_carrier(request, shipment) or self.is_moderator(request, shipment)
 
-            return response.status_code == status.HTTP_200_OK
+    def has_permission(self, request, view):
 
-        def is_moderator():
-            """
-            Custom permission for moderator documents management access
-            """
-            response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{obj.shipment.moderator_wallet_id}/',
-                                                     headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+        shipment_id = request.parser_context['kwargs'].get('shipment_pk', None)
+        if not shipment_id:
+            return True
 
-            return response.status_code == status.HTTP_200_OK
+        shipment = Shipment.objects.filter(id=shipment_id).first()
 
-        def is_shipper():
-            """
-            Custom permission for shipper documents management access
-            """
-            response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{obj.shipment.shipper_wallet_id}/',
-                                                     headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+        return has_owner_access(request, shipment) or self.is_shipper(request, shipment) or \
+            self.is_carrier(request, shipment) or self.is_moderator(request, shipment)
 
-            return response.status_code == status.HTTP_200_OK
+    def is_carrier(self, request, shipment):
+        """
+        Custom permission for carrier documents management access
+        """
+        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.carrier_wallet_id}/',
+                                                 headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
 
-        return has_owner_access(request, obj) or is_shipper() or is_carrier() or is_moderator()
+        return response.status_code == status.HTTP_200_OK
+
+    def is_moderator(self, request, shipment):
+        """
+        Custom permission for moderator documents management access
+        """
+        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.moderator_wallet_id}/',
+                                                 headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+
+        return response.status_code == status.HTTP_200_OK
+
+    def is_shipper(self, request, shipment):
+        """
+        Custom permission for shipper documents management access
+        """
+        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.shipper_wallet_id}/',
+                                                 headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+
+        return response.status_code == status.HTTP_200_OK

--- a/tests/profiles-enabled/test_documents.py
+++ b/tests/profiles-enabled/test_documents.py
@@ -428,9 +428,8 @@ class DocumentAPITests(APITestCase):
             mock_is_carrier.return_value = False
             mock_is_moderator.return_value = False
 
-            # url = reverse('document-list', kwargs={'version': 'v1'})
-
             # The shipper should be able to upload a document
+            # This is equivalently valid for carrier and moderator
             self.set_user(self.shipper_user)
             response = self.client.post(url, file_data, format='json')
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/tests/profiles-enabled/test_documents.py
+++ b/tests/profiles-enabled/test_documents.py
@@ -236,13 +236,6 @@ class PdfDocumentViewSetAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data), 0)
 
-        # List of all documents attached to a shipment
-        url = reverse('shipment-documents-list', kwargs={'version': 'v1', 'shipment_pk': self.shipment.id})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()['data']
-        self.assertEqual(len(data), 2)
-
 
 class DocumentAPITests(APITestCase):
 
@@ -435,14 +428,12 @@ class DocumentAPITests(APITestCase):
             mock_is_carrier.return_value = False
             mock_is_moderator.return_value = False
 
-            url = reverse('document-list', kwargs={'version': 'v1'})
+            # url = reverse('document-list', kwargs={'version': 'v1'})
 
             # The shipper should be able to upload a document
             self.set_user(self.shipper_user)
             response = self.client.post(url, file_data, format='json')
-            data = response.json()['data']
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-            # self.assertEqual(len(data), 4)
             self.assertEqual(mock_is_shipper.call_count, 1)
             self.assertEqual(mock_is_carrier.call_count, 0)
             self.assertEqual(mock_is_moderator.call_count, 0)


### PR DESCRIPTION
With this PR the documents access permissions have been improved.
- Add documents' permission test case
- Refactor `documents.views`
- Add support do document creation on nested route.
Once approved, we will be able to get the list of documents and create a document from the nested route: `/api/v1/shipments/{shipment_id}/documents/`