### PR TITLE
Allow a shipment's device to be set to none

### DIFF
--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -205,6 +205,7 @@ class ShipmentUpdateSerializer(ShipmentSerializer):
     def validate_device_id(self, device_id):
         auth = self.context['auth']
         if not device_id:
+            print('In validate_device_id: ', device_id)
             if not self.instance.device:
                 return None
             if not self.instance.delivery_act or self.instance.delivery_act >= datetime.now(timezone.utc):

--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -1,6 +1,6 @@
 import json
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 
 import boto3
 import pytz
@@ -205,11 +205,10 @@ class ShipmentUpdateSerializer(ShipmentSerializer):
 
     def validate_device_id(self, device_id):
         auth = self.context['auth']
-        shipment = self.context['shipment']
         if not device_id or device_id == 'null':
-            if not shipment.device:
+            if not self.instance.device:
                 return None
-            if not shipment.delivery_act or shipment.delivery_act >= datetime.utcnow().replace(tzinfo=pytz.UTC):
+            if not self.instance.delivery_act or self.instance.delivery_act >= datetime.now(timezone.utc):
                 raise serializers.ValidationError('Cannot remove device from Shipment in progress')
             return None
 

--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 
 import boto3
-import pytz
 from botocore.exceptions import ClientError
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -205,7 +204,7 @@ class ShipmentUpdateSerializer(ShipmentSerializer):
 
     def validate_device_id(self, device_id):
         auth = self.context['auth']
-        if not device_id or device_id == 'null':
+        if not device_id:
             if not self.instance.device:
                 return None
             if not self.instance.delivery_act or self.instance.delivery_act >= datetime.now(timezone.utc):

--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -205,7 +205,6 @@ class ShipmentUpdateSerializer(ShipmentSerializer):
     def validate_device_id(self, device_id):
         auth = self.context['auth']
         if not device_id:
-            print('In validate_device_id: ', device_id)
             if not self.instance.device:
                 return None
             if not self.instance.delivery_act or self.instance.delivery_act >= datetime.now(timezone.utc):

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -154,7 +154,7 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         log_metric('transmission.info', tags={'method': 'shipments.update', 'module': __name__})
 
         serializer = ShipmentUpdateSerializer(instance, data=request.data, partial=partial,
-                                              context={'auth': get_jwt_from_request(request), 'shipment': instance})
+                                              context={'auth': get_jwt_from_request(request)})
         serializer.is_valid(raise_exception=True)
 
         shipment = self.perform_update(serializer)

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -154,7 +154,7 @@ class ShipmentViewSet(viewsets.ModelViewSet):
         log_metric('transmission.info', tags={'method': 'shipments.update', 'module': __name__})
 
         serializer = ShipmentUpdateSerializer(instance, data=request.data, partial=partial,
-                                              context={'auth': get_jwt_from_request(request)})
+                                              context={'auth': get_jwt_from_request(request), 'shipment': instance})
         serializer.is_valid(raise_exception=True)
 
         shipment = self.perform_update(serializer)

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -1686,6 +1686,7 @@ class ShipmentWithIoTAPITests(APITestCase):
 
             response = self.create_shipment()
             assert response.status_code == status.HTTP_202_ACCEPTED
+            mocked_call_count += 1
             assert mocked.call_count == mocked_call_count
 
             response_json = response.json()

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -1593,24 +1593,6 @@ class ShipmentWithIoTAPITests(APITestCase):
                 'shipmentId': shipment['id']
             }})
 
-            # shipment_obj = Shipment.objects.filter(id=shipment['id']).first()
-            # shipment_obj.delivery_act = '2018-08-22T17:44:39.874352Z'
-            # shipment_obj.save()
-            # # Test Shipment null Device ID updates shadow
-            # response = self.set_device_id(shipment['id'], None, None)
-            # assert response.status_code == status.HTTP_202_ACCEPTED
-            # mocked_call_count += 1
-            # assert mocked.call_count == mocked_call_count
-            # shipment_obj.refresh_from_db()
-            # shipment_obj.delivery_act = None
-            # shipment_obj.save()
-
-            # # Reset initial DEVICE_ID
-            # response = self.set_device_id(shipment['id'], DEVICE_ID, CERTIFICATE_ID)
-            # assert response.status_code == status.HTTP_202_ACCEPTED
-            # mocked_call_count += 1
-            # assert mocked.call_count == mocked_call_count
-
             # Test Shipment update with Device ID updates shadow
             response = self.set_device_id(shipment['id'], device_2_id, device_2_cert_id)
             assert response.status_code == status.HTTP_202_ACCEPTED


### PR DESCRIPTION
When a shipment has ended, as evidenced by the delivery_act, then it makes sense to be able to remove the device from the shipment. This wasn't able to happen before as it attempted to make a call to profiles to a device with a null id. This fixes that issue, and allows a user to set a completed shipment's device to null.