### PR TITLE
Feature/revisit permission links

### DIFF
--- a/apps/shipments/models.py
+++ b/apps/shipments/models.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import pytz
 import geojson
 
@@ -394,6 +394,12 @@ class PermissionLink(models.Model):
     name = models.CharField(null=False, max_length=255)
     shipment = models.ForeignKey(Shipment, on_delete=models.CASCADE, null=False)
     created_at = models.DateTimeField(auto_now_add=True)
+
+    @property
+    def is_valid(self):
+        if not self.expiration_date:
+            return True
+        return datetime.now(timezone.utc) < self.expiration_date
 
 
 class LoadShipment(models.Model):

--- a/apps/shipments/permissions.py
+++ b/apps/shipments/permissions.py
@@ -40,8 +40,7 @@ class IsOwnerOrShared(permissions.IsAuthenticated):
             try:
                 permission_obj = PermissionLink.objects.get(pk=permission_link)
             except ObjectDoesNotExist:
-                permission_obj = None
-
+                pass
         if (not permission_obj or not permission_obj.is_valid) and not shipment_pk:
             return super(IsOwnerOrShared, self).has_permission(request, view)
 

--- a/apps/shipments/permissions.py
+++ b/apps/shipments/permissions.py
@@ -35,6 +35,10 @@ class IsOwnerOrShared(permissions.IsAuthenticated):
         permission_link = request.query_params.get('permission_link', None)
         shipment_pk = request.parser_context['kwargs'].get('pk', None)
 
+        # The shipments can only be accessible via permission link only on shipment-detail endpoint
+        if permission_link and not shipment_pk:
+            return False
+
         permission_obj = None
         if permission_link:
             try:

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -50,7 +50,7 @@ class ShipmentViewSet(viewsets.ModelViewSet):
                     LOG.warning(f'User: {self.request.user}, is trying to access a shipment with permission link: '
                                 f'{permission_link}')
                     raise PermissionDenied('No permission link found.')
-                queryset = queryset.filter(Q(owner_access_filter(self.request)) | Q(pk=permission_link_obj.shipment.pk))
+                queryset = queryset.filter(owner_access_filter(self.request) | Q(pk=permission_link_obj.shipment.pk))
             else:
                 queryset = queryset.filter(owner_access_filter(self.request))
         return queryset

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timezone
 from string import Template
 
 from django.conf import settings
@@ -43,14 +42,15 @@ class ShipmentViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         queryset = self.queryset
         if settings.PROFILES_ENABLED:
-            if 'permission_link' in self.request.query_params and self.request.query_params['permission_link']:
+            permission_link = self.request.query_params.get('permission_link', None)
+            if permission_link:
                 try:
-                    permission_link = PermissionLink.objects.get(pk=self.request.query_params['permission_link'])
-                    if permission_link.expiration_date and permission_link.expiration_date < datetime.now(timezone.utc):
-                        queryset = queryset.filter(owner_access_filter(self.request))
+                    permission_link_obj = PermissionLink.objects.get(pk=permission_link)
                 except ObjectDoesNotExist:
+                    LOG.warning(f'User: {self.request.user}, is trying to access a shipment with permission link: '
+                                f'{permission_link}')
                     raise PermissionDenied('No permission link found.')
-                queryset = queryset.filter(owner_access_filter(self.request) | Q(pk=permission_link.shipment.pk))
+                queryset = queryset.filter(Q(owner_access_filter(self.request)) | Q(pk=permission_link_obj.shipment.pk))
             else:
                 queryset = queryset.filter(owner_access_filter(self.request))
         return queryset

--- a/tests/postman.collection.Transmission.json
+++ b/tests/postman.collection.Transmission.json
@@ -1268,7 +1268,7 @@
                     "path": [
                       "api",
                       "v1",
-                      "documents",
+                      "shipments",
                       "{{shipment_id}}",
                       "permission_links",
                       ""
@@ -1295,7 +1295,7 @@
                     "path": [
                       "api",
                       "v1",
-                      "documents",
+                      "shipments",
                       "{{shipment_id}}",
                       "permission_links",
                       ""

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import boto3
 import httpretty
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from dateutil import parser
 from django.conf import settings as test_settings
 from jose import jws
@@ -1140,18 +1140,22 @@ class ShipmentAPITests(APITestCase):
         self.create_shipment()
         url = reverse('shipment-permissions-list', kwargs={'version': 'v1', 'shipment_pk': self.shipments[0].id})
 
+        today = datetime.now(timezone.utc)
+        yesterday = today + timedelta(days=-1)
+        tomorrow = today + timedelta(days=1)
+
         valid_permission_no_exp, content_type = create_form_content({
             'name': 'test'
         })
 
         valid_permission_past_exp, content_type = create_form_content({
             'name': 'test',
-            'expiration_date': '2018-08-22T17:44:39.874352'
+            'expiration_date': yesterday.isoformat()
         })
 
         valid_permission_with_exp, content_type = create_form_content({
             'name': 'test',
-            'expiration_date': '2118-08-22T17:44:39.874352'
+            'expiration_date': tomorrow.isoformat()
         })
 
         shipment_update_info, content_type = create_form_content({

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -1222,7 +1222,7 @@ class ShipmentAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         # An authenticated user can only access the list of shipments he owns with a valid permission link
-        # user_2 owns 1 shipment and has the permission link for another one doesn't, total 2
+        # user_2 owns 1 shipment and has the permission link for the other one, total 2 shipments
         response = self.client.get(f'{url_shipment_list}?permission_link={valid_permission_id_with_exp}')
         response_json = response.json()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1259,7 +1259,7 @@ class ShipmentAPITests(APITestCase):
         response = self.client.get(f'{shipment_url}?permission_link=')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-        # Assert that a tier user with valid permission cannot modified a shipment
+        # Assert that a tier user with valid permission cannot modify a shipment
         response = self.client.patch(f'{shipment_url}?permission_link={valid_permission_id_with_exp}',
                                      shipment_update_info, content_type=content_type)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -1221,18 +1221,17 @@ class ShipmentAPITests(APITestCase):
         response = self.client.get(shipment_url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-        # An authenticated user can only access the list of shipments he owns with a valid permission link
-        # user_2 owns 1 shipment and has the permission link for the other one, total 2 shipments
+        # Shipments with permission links can only be accessible via shipments-detail endpoint
+        # not shipments-list response status should be 403
         response = self.client.get(f'{url_shipment_list}?permission_link={valid_permission_id_with_exp}')
-        response_json = response.json()
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response_json['data']), 2)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         response = self.client.get(f'{shipment_url}?permission_link={valid_permission_id}')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Assert that users cannot update or delete shipments when using a permission link
-        response = self.client.patch(f'{shipment_url}?permission_link={valid_permission_id}', shipment_update_info, content_type=content_type)
+        response = self.client.patch(f'{shipment_url}?permission_link={valid_permission_id}',
+                                     shipment_update_info, content_type=content_type)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         # Assert that users cannot update or delete shipments when using a permission link


### PR DESCRIPTION
This PR improves the shipment's permission links access permissions
- Assure that transmission db doesn't get hit by malicious requests by moving most of the permission class logic to the `has_permission` method which is kind of the permission class proxy.
- Add additional tests
- Simplify the shipment's view `get_queryset` method