### PR TITLE
Optimize Shipment Creation Flow

### DIFF
--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -65,8 +65,8 @@ class AsyncTask:
             contract_version, unsigned_tx = getattr(self.rpc_client, self.async_job.parameters['rpc_method'])(
                 *self.async_job.parameters['rpc_parameters'])
             for shipment in self.async_job.listeners.filter(Model='shipments.Shipment'):
-                shipment.contract_version = contract_version
-                shipment.save()
+                from apps.shipments.models import Shipment
+                Shipment.objects.filter(id=shipment.id).update(contract_version=contract_version)
         else:
             unsigned_tx = getattr(self.rpc_client, self.async_job.parameters['rpc_method'])(
                 *self.async_job.parameters['rpc_parameters'])

--- a/apps/shipments/events.py
+++ b/apps/shipments/events.py
@@ -47,7 +47,7 @@ class LoadEventHandler:
         if shipment.moderator_wallet_id:
             shipment.set_moderator()
         shipment.set_vault_uri(shipment.vault_uri)
-        shipment.set_vault_hash(signature['hash'], action_type=AsyncActionType.SHIPMENT)
+        shipment.set_vault_hash(signature['hash'], action_type=AsyncActionType.SHIPMENT, rate_limit=0)
 
     @staticmethod
     def shipment_carrier_set(event, shipment):

--- a/apps/shipments/tasks.py
+++ b/apps/shipments/tasks.py
@@ -2,6 +2,7 @@
 import logging
 
 from celery import shared_task
+from django.conf import settings
 from influxdb_metrics.loader import log_metric
 
 from apps.jobs.models import AsyncActionType
@@ -25,6 +26,6 @@ def tracking_data_update(self, shipment_id, payload):
                                              shipment.vault_id,
                                              payload)
     shipment.set_vault_hash(signature['hash'],
-                            rate_limit=True,
+                            rate_limit=settings.TRACKING_VAULT_HASH_RATE_LIMIT,
                             action_type=AsyncActionType.TRACKING,
                             use_updated_by=False)

--- a/conf/apps.py
+++ b/conf/apps.py
@@ -8,7 +8,8 @@ CELERY_WALLET_RETRY = 30
 CELERY_TXHASH_RETRY = 30
 
 # Time in minutes to be used when rate limiting vault hash updates
-VAULT_HASH_RATE_LIMIT = 120 if ENVIRONMENT == 'PROD' else 5
+TRACKING_VAULT_HASH_RATE_LIMIT = 120 if ENVIRONMENT == 'PROD' else 5
+DATA_VAULT_HASH_RATE_LIMIT = 5
 
 # Set default Shipment data version
 SHIPMENT_SCHEMA_VERSION = "1.2.1"

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -418,7 +418,12 @@ class ShipmentAPITests(APITestCase):
                     "vault_signed": {'hash': "TEST_VAULT_SIGNATURE"}
                 }
             })
-            self.shipments[0].save()
+
+            with mock.patch('apps.iot_client.requests.Session.put') as mocked:
+                mocked.return_value = mocked_rpc_response({'data': {
+                    'shipmentId': self.shipments[0].id
+                }})
+                self.shipments[0].save()
 
         url = reverse('shipment-tracking', kwargs={'version': 'v1', 'pk': self.shipments[0].id})
 
@@ -462,7 +467,11 @@ class ShipmentAPITests(APITestCase):
 
             # Creating a new shipment with a device for which the certificate has expired and a new one has been issued
             self.shipments[0].device = None
-            self.shipments[0].save()
+            with mock.patch('apps.iot_client.requests.Session.put') as mocked:
+                mocked.return_value = mocked_rpc_response({'data': {
+                    'shipmentId': None
+                }})
+                self.shipments[0].save()
             device.certificate_id = expired_certificate
             device.save()
             device.refresh_from_db()

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -497,7 +497,11 @@ class ShipmentAPITests(APITestCase):
                 mock_wallet_validation.return_value = SHIPPER_WALLET_ID
                 mock_storage_validation.return_value = STORAGE_CRED_ID
 
-                response = self.client.post(url, post_data, format='json')
+                with mock.patch('apps.iot_client.requests.Session.put') as mocked:
+                    mocked.return_value = mocked_rpc_response({'data': {
+                        'shipmentId': 'dunno yet'
+                    }})
+                    response = self.client.post(url, post_data, format='json')
                 self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
                 # The new certificate should be attached to the shipment's device


### PR DESCRIPTION
My task was to revisit the shipment creation flow and make sure no unnecessary RPC calls and/or Eth transactions were being made.
- Fixed extraneous add_shipment_data/update_vault_hash call in shipment creation flow
- Added batching for all non-initial shipment data vault hash updates
- Fixed unrelated issue in unit tests where IoT shadow calls were not properly mocked