### PR TITLE
Grant shipment carrier/moderator's access to a shipment

### DIFF
--- a/apps/documents/permissions.py
+++ b/apps/documents/permissions.py
@@ -36,7 +36,7 @@ class UserHasPermission(permissions.BasePermission):
         """
         Custom permission for carrier documents management access
         """
-        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.carrier_wallet_id}/',
+        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.carrier_wallet_id}/?is_active',
                                                  headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
 
         return response.status_code == status.HTTP_200_OK
@@ -45,16 +45,17 @@ class UserHasPermission(permissions.BasePermission):
         """
         Custom permission for moderator documents management access
         """
-        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.moderator_wallet_id}/',
-                                                 headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+        if shipment.moderator_wallet_id:
+            response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.moderator_wallet_id}/?is_active',
+                                                     headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
 
-        return response.status_code == status.HTTP_200_OK
+        return shipment.moderator_wallet_id and response.status_code == status.HTTP_200_OK
 
     def is_shipper(self, request, shipment):
         """
         Custom permission for shipper documents management access
         """
-        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.shipper_wallet_id}/',
+        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.shipper_wallet_id}/?is_active',
                                                  headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
 
         return response.status_code == status.HTTP_200_OK

--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -127,7 +127,7 @@ class TransactionViewSet(mixins.RetrieveModelMixin,
                 wallet_id = self.request.query_params.get('wallet_id')
 
                 wallet_response = settings.REQUESTS_SESSION.get(
-                    f'{settings.PROFILES_URL}/api/v1/wallet/{wallet_id}/',
+                    f'{settings.PROFILES_URL}/api/v1/wallet/{wallet_id}/?is_active',
                     headers={'Authorization': f'JWT {get_jwt_from_request(request)}'}
                 )
 

--- a/apps/shipments/permissions.py
+++ b/apps/shipments/permissions.py
@@ -16,7 +16,7 @@ class IsShipmentOwner(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj):
-        shipment_id = request.parser_context['kwargs'].get('shipment_pk', None)
+        shipment_id = view.kwargs['shipment_pk']
 
         shipment = Shipment.objects.get(id=shipment_id)
 
@@ -24,7 +24,7 @@ class IsShipmentOwner(permissions.BasePermission):
                 self.is_carrier(request, shipment) or self.is_moderator(request, shipment))
 
     def has_permission(self, request, view):
-        shipment_id = request.parser_context['kwargs'].get('shipment_pk', None)
+        shipment_id = view.kwargs['shipment_pk']
         if not shipment_id and request.user.is_authenticated:
             return True
 
@@ -84,7 +84,7 @@ class IsOwnerOrShared(permissions.IsAuthenticated):
     def has_permission(self, request, view):
 
         permission_link = request.query_params.get('permission_link', None)
-        shipment_pk = request.parser_context['kwargs'].get('pk', None)
+        shipment_pk = view.kwargs['shipment_pk']
 
         # The shipments can only be accessible via permission link only on shipment-detail endpoint
         if permission_link and not shipment_pk:

--- a/apps/shipments/permissions.py
+++ b/apps/shipments/permissions.py
@@ -84,7 +84,7 @@ class IsOwnerOrShared(permissions.IsAuthenticated):
     def has_permission(self, request, view):
 
         permission_link = request.query_params.get('permission_link', None)
-        shipment_pk = request.parser_context['kwargs'].get('shipment_pk', None)
+        shipment_pk = request.parser_context['kwargs'].get('pk', None)
 
         # The shipments can only be accessible via permission link only on shipment-detail endpoint
         if permission_link and not shipment_pk:

--- a/apps/shipments/permissions.py
+++ b/apps/shipments/permissions.py
@@ -84,7 +84,7 @@ class IsOwnerOrShared(permissions.IsAuthenticated):
     def has_permission(self, request, view):
 
         permission_link = request.query_params.get('permission_link', None)
-        shipment_pk = view.kwargs['shipment_pk']
+        shipment_pk = request.parser_context['kwargs'].get('shipment_pk', None)
 
         # The shipments can only be accessible via permission link only on shipment-detail endpoint
         if permission_link and not shipment_pk:

--- a/apps/shipments/permissions.py
+++ b/apps/shipments/permissions.py
@@ -25,8 +25,6 @@ class IsShipmentOwner(permissions.BasePermission):
 
     def has_permission(self, request, view):
         shipment_id = view.kwargs['shipment_pk']
-        if not shipment_id and request.user.is_authenticated:
-            return True
 
         shipment = Shipment.objects.get(id=shipment_id)
 

--- a/apps/shipments/permissions.py
+++ b/apps/shipments/permissions.py
@@ -1,17 +1,66 @@
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from rest_framework import permissions
+from rest_framework import permissions, status
 
+from apps.authentication import get_jwt_from_request
 from apps.permissions import has_owner_access
 from .models import PermissionLink, Shipment
+
+
+PROFILES_URL = f'{settings.PROFILES_URL}/api/v1/wallet'
 
 
 class IsShipmentOwner(permissions.BasePermission):
     """
     Custom permission to only allow owners of an object to edit it (for use in related querysets)
     """
+
+    def has_object_permission(self, request, view, obj):
+        shipment_id = request.parser_context['kwargs'].get('shipment_pk', None)
+
+        shipment = Shipment.objects.get(id=shipment_id)
+
+        return (has_owner_access(request, shipment) or self.is_shipper(request, shipment) or
+                self.is_carrier(request, shipment) or self.is_moderator(request, shipment))
+
     def has_permission(self, request, view):
-        shipment = Shipment.objects.get(pk=view.kwargs['shipment_pk'])
-        return has_owner_access(request, shipment)
+        shipment_id = request.parser_context['kwargs'].get('shipment_pk', None)
+        if not shipment_id:
+            return True
+
+        shipment = Shipment.objects.get(id=shipment_id)
+
+        return has_owner_access(request, shipment) or self.is_shipper(request, shipment) or \
+               self.is_carrier(request, shipment) or self.is_moderator(request, shipment)
+
+    def is_carrier(self, request, shipment):
+        """
+        Custom permission for carrier documents management access
+        """
+        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.carrier_wallet_id}/?is_active',
+                                                 headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+
+        return response.status_code == status.HTTP_200_OK and request.method in ('GET', 'PATCH')
+
+    def is_moderator(self, request, shipment):
+        """
+        Custom permission for moderator documents management access
+        """
+        if shipment.moderator_wallet_id:
+            response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.moderator_wallet_id}/?is_active',
+                                                     headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+
+        return (shipment.moderator_wallet_id and response.status_code == status.HTTP_200_OK and
+                request.method in ('GET', 'PATCH'))
+
+    def is_shipper(self, request, shipment):
+        """
+        Custom permission for shipper documents management access
+        """
+        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.shipper_wallet_id}/?is_active',
+                                                 headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+
+        return response.status_code == status.HTTP_200_OK and request.method in ('GET', 'PATCH')
 
 
 class IsListenerOwner(permissions.BasePermission):
@@ -79,7 +128,37 @@ class IsOwnerOrShared(permissions.IsAuthenticated):
         return self.check_has_owner_access(request, shipment)
 
     def check_has_owner_access(self, request, obj):
-        return request.user.is_authenticated and has_owner_access(request, obj)
+        return request.user.is_authenticated and (has_owner_access(request, obj) or self.is_shipper(request, obj) or
+                                                  self.is_carrier(request, obj) or self.is_moderator(request, obj))
+
+    def is_carrier(self, request, shipment):
+        """
+        Custom permission for carrier documents management access
+        """
+        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.carrier_wallet_id}/?is_active',
+                                                 headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+
+        return response.status_code == status.HTTP_200_OK and request.method in ('GET', 'PATCH')
+
+    def is_moderator(self, request, shipment):
+        """
+        Custom permission for moderator documents management access
+        """
+        if shipment.moderator_wallet_id:
+            response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.moderator_wallet_id}/?is_active',
+                                                     headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+
+        return (shipment.moderator_wallet_id and response.status_code == status.HTTP_200_OK and
+                request.method in ('GET', 'PATCH'))
+
+    def is_shipper(self, request, shipment):
+        """
+        Custom permission for shipper documents management access
+        """
+        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.shipper_wallet_id}/?is_active',
+                                                 headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
+
+        return response.status_code == status.HTTP_200_OK and request.method in ('GET', 'PATCH')
 
 
 class IsAuthenticatedOrDevice(permissions.IsAuthenticated):

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -51,6 +51,8 @@ class ShipmentViewSet(viewsets.ModelViewSet):
                                 f'{permission_link}')
                     raise PermissionDenied('No permission link found.')
                 queryset = queryset.filter(owner_access_filter(self.request) | Q(pk=permission_link_obj.shipment.pk))
+            elif self.detail:
+                return queryset
             else:
                 queryset = queryset.filter(owner_access_filter(self.request))
         return queryset


### PR DESCRIPTION
The owner of a shipment's carrier/moderator wallet need access to view a shipment and update it, even if they were not the original creators of the shipment. They are allowed to access the shipment and update it, but only the original creator has the ability to actually delete a shipment.