### PR TITLE
Optional trailing slash fix

### DIFF
--- a/apps/routing.py
+++ b/apps/routing.py
@@ -16,6 +16,8 @@ limitations under the License.
 
 from channels.routing import ProtocolTypeRouter, URLRouter
 from django.conf.urls import url
+from rest_framework_nested import routers as drf_nested_routers
+
 from . import consumers
 
 
@@ -30,3 +32,9 @@ application = ProtocolTypeRouter({
         websocket_urlpatterns,
     ),
 })
+
+
+class OptionalSlashRouter(drf_nested_routers.SimpleRouter):
+    def __init__(self):
+        super(OptionalSlashRouter, self).__init__()
+        self.trailing_slash = '/?'

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -19,6 +19,7 @@ from django.views.generic import TemplateView
 from rest_framework.urlpatterns import format_suffix_patterns
 from rest_framework_nested import routers as drf_nested_routers
 
+from apps.routing import OptionalSlashRouter
 from apps.jobs import views as jobs
 from apps.shipments import views as shipments
 from apps.eth import views as eth
@@ -28,7 +29,7 @@ from apps.documents import views as documents
 API_PREFIX = r'^api/(?P<version>(v1|v2))'
 
 # pylint: disable=invalid-name
-router = drf_nested_routers.SimpleRouter()
+router = OptionalSlashRouter()
 
 router.register(f'{API_PREFIX[1:]}/shipments', shipments.ShipmentViewSet)
 router.register(f'{API_PREFIX[1:]}/jobs', jobs.JobsViewSet, base_name='job')


### PR DESCRIPTION
When making an API call via PATCH, the call would be redirected correctly, but the data inside would not be. For example, you could make a call to update a shipment's contents and while a 200 would be returned nothing would have actually changed. This fixes that issue and ensure that whether or not there is a trailing slash a patch will successfully update the data.