### PR TITLE
Feature/move documents endpoint to nested

### DIFF
--- a/apps/documents/permissions.py
+++ b/apps/documents/permissions.py
@@ -28,7 +28,7 @@ class UserHasPermission(permissions.BasePermission):
 
         shipment_id = request.parser_context['kwargs'].get('shipment_pk', None)
         if not shipment_id:
-            # The document's views are only accessible via nested route
+            # The document's views are only accessible via nested routes
             return False
         try:
             shipment = Shipment.objects.get(id=shipment_id)

--- a/apps/documents/permissions.py
+++ b/apps/documents/permissions.py
@@ -26,7 +26,7 @@ class UserHasPermission(permissions.BasePermission):
 
     def has_permission(self, request, view):
 
-        shipment_id = request.parser_context['kwargs'].get('shipment_pk', None)
+        shipment_id = view['kwargs'].get('shipment_pk', None)
         if not shipment_id:
             # The document's views are only accessible via nested routes
             return False

--- a/apps/documents/permissions.py
+++ b/apps/documents/permissions.py
@@ -25,7 +25,8 @@ class UserHasPermission(permissions.BasePermission):
 
         shipment_id = request.parser_context['kwargs'].get('shipment_pk', None)
         if not shipment_id:
-            return True
+            # The shipment's documents view is only accessible on nested route
+            return False
 
         shipment = Shipment.objects.get(id=shipment_id)
 

--- a/apps/documents/permissions.py
+++ b/apps/documents/permissions.py
@@ -26,7 +26,7 @@ class UserHasPermission(permissions.BasePermission):
 
     def has_permission(self, request, view):
 
-        shipment_id = view['kwargs'].get('shipment_pk', None)
+        shipment_id = view.kwargs.get('shipment_pk', None)
         if not shipment_id:
             # The document's views are only accessible via nested routes
             return False

--- a/apps/documents/permissions.py
+++ b/apps/documents/permissions.py
@@ -25,7 +25,7 @@ class UserHasPermission(permissions.BasePermission):
 
         shipment_id = request.parser_context['kwargs'].get('shipment_pk', None)
         if not shipment_id:
-            # The shipment's documents view is only accessible on nested route
+            # The document's views are only accessible via nested route
             return False
 
         shipment = Shipment.objects.get(id=shipment_id)

--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -68,6 +68,15 @@ class DocumentCreateSerializer(DocumentSerializer):
             exclude = ('shipment',)
         meta_fields = ('presigned_s3',)
 
+    def validate_shipment_id(self, shipment_id):
+        shipment_id_parser = self.context['shipment_id_parser']
+        if shipment_id != shipment_id_parser:
+            LOG.warning(f'Trying to create document on shipment: {shipment_id_parser}, '
+                        f'with shipment: {shipment_id}, as attribute')
+            raise serializers.ValidationError(f'Invalid shipment_id: {shipment_id}')
+
+        return shipment_id
+
 
 class DocumentRetrieveSerializer(DocumentSerializer):
     presigned_s3_thumbnail = serializers.SerializerMethodField()

--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -58,7 +58,6 @@ class DocumentCreateSerializer(DocumentSerializer):
     document_type = UpperEnumField(DocumentType, lenient=True, ints_as_names=True)
     file_type = UpperEnumField(FileType, lenient=True, ints_as_names=True)
     upload_status = UpperEnumField(UploadStatus, read_only=True, ints_as_names=True)
-    shipment_id = serializers.CharField(max_length=36)
 
     class Meta:
         model = Document
@@ -68,14 +67,9 @@ class DocumentCreateSerializer(DocumentSerializer):
             exclude = ('shipment',)
         meta_fields = ('presigned_s3',)
 
-    def validate_shipment_id(self, shipment_id):
-        shipment_id_parser = self.context['shipment_id_parser']
-        if shipment_id != shipment_id_parser:
-            LOG.warning(f'Trying to create document on shipment: {shipment_id_parser}, '
-                        f'with shipment: {shipment_id}, as attribute')
-            raise serializers.ValidationError(f'Invalid shipment_id: {shipment_id}')
-
-        return shipment_id
+    def validate(self, attrs):
+        attrs['shipment_id'] = self.context['shipment_id']
+        return attrs
 
 
 class DocumentRetrieveSerializer(DocumentSerializer):

--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -67,9 +67,8 @@ class DocumentCreateSerializer(DocumentSerializer):
             exclude = ('shipment',)
         meta_fields = ('presigned_s3',)
 
-    def validate(self, attrs):
-        attrs['shipment_id'] = self.context['shipment_id']
-        return attrs
+    def create(self, validated_data):
+        return Document.objects.create(**validated_data, **self.context)
 
 
 class DocumentRetrieveSerializer(DocumentSerializer):

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -38,7 +38,7 @@ class DocumentViewSet(mixins.CreateModelMixin,
     def get_queryset(self):
         queryset = self.queryset
         if settings.PROFILES_ENABLED:
-            shipment_id = self.request.parser_context['kwargs']['shipment_pk']
+            shipment_id = self.kwargs['shipment_pk']
             return queryset.filter(shipment__id=shipment_id)
         return queryset.filter(owner_id=get_owner_id(self.request))
 
@@ -56,8 +56,8 @@ class DocumentViewSet(mixins.CreateModelMixin,
         LOG.debug(f'Creating a document object.')
         log_metric('transmission.info', tags={'method': 'documents.create', 'module': __name__})
 
-        shipment_id = self.request.parser_context['kwargs']['shipment_pk']
-        serializer = DocumentCreateSerializer(data=request.data, context={'shipment_id_parser': shipment_id})
+        shipment_id = self.kwargs['shipment_pk']
+        serializer = DocumentCreateSerializer(data=request.data, context={'shipment_id': shipment_id})
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -38,7 +38,7 @@ class DocumentViewSet(mixins.CreateModelMixin,
     def get_queryset(self):
         queryset = self.queryset
         if settings.PROFILES_ENABLED:
-            shipment_id = self.request.parser_context['kwargs'].get('shipment_pk', None)
+            shipment_id = self.request.parser_context['kwargs']['shipment_pk']
             return queryset.filter(shipment__id=shipment_id)
         return queryset.filter(owner_id=get_owner_id(self.request))
 
@@ -56,7 +56,8 @@ class DocumentViewSet(mixins.CreateModelMixin,
         LOG.debug(f'Creating a document object.')
         log_metric('transmission.info', tags={'method': 'documents.create', 'module': __name__})
 
-        serializer = DocumentCreateSerializer(data=request.data)
+        shipment_id = self.request.parser_context['kwargs']['shipment_pk']
+        serializer = DocumentCreateSerializer(data=request.data, context={'shipment_id_parser': shipment_id})
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -39,8 +39,7 @@ class DocumentViewSet(mixins.CreateModelMixin,
         queryset = self.queryset
         if settings.PROFILES_ENABLED:
             shipment_id = self.request.parser_context['kwargs'].get('shipment_pk', None)
-            if shipment_id:
-                return queryset.filter(shipment__id=shipment_id)
+            return queryset.filter(shipment__id=shipment_id)
         return queryset.filter(owner_id=get_owner_id(self.request))
 
     def perform_create(self, serializer):

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -27,7 +27,6 @@ LOG = logging.getLogger('transmission')
 class DocumentViewSet(mixins.CreateModelMixin,
                       mixins.RetrieveModelMixin,
                       mixins.ListModelMixin,
-                      mixins.UpdateModelMixin,
                       viewsets.GenericViewSet):
     queryset = Document.objects.all()
     serializer_class = DocumentSerializer
@@ -62,23 +61,6 @@ class DocumentViewSet(mixins.CreateModelMixin,
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
-
-    def update(self, request, *args, **kwargs):
-        """
-        Update document object status according to upload status: COMPLETE or FAILED
-        """
-        partial = kwargs.pop('partial', False)
-        instance = self.get_object()
-        LOG.debug(f'Updating document {instance.id} with new details.')
-        log_metric('transmission.info', tags={'method': 'documents.update', 'module': __name__})
-
-        serializer = DocumentRetrieveSerializer(instance, data=request.data, partial=partial,
-                                                context={'auth': request.auth})
-        serializer.is_valid(raise_exception=True)
-
-        self.perform_update(serializer)
-
-        return Response(serializer.data, status=status.HTTP_200_OK)
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()

--- a/apps/schema/static/schema/swagger.yaml
+++ b/apps/schema/static/schema/swagger.yaml
@@ -202,6 +202,7 @@ paths:
         - $ref: '#/components/parameters/document/uploadStatus'
       tags:
       - Shipments
+      - Documents
       responses:
         '200':
           description: *response_200
@@ -215,6 +216,104 @@ paths:
             application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/errors/401'
+
+    post:
+      summary: Create document
+      description: |
+        Create a new `Document` owned by the current user.
+
+        A presigned S3 request will be generated with credentials to POST a new file of the specified type to S3.
+        Engine will then upload the file to the Shipment's vault.
+
+        Note: `Document.upload_status` will need to be updated to `COMPLETE` in order for the document to be retrieved
+        from S3.
+      tags:
+        - Documents
+      responses:
+        '202':
+          description: *response_202
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/document/createResponse'
+        '401':
+          description: *response_401
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/errors/401'
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/requestBodies/document/createRequest'
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/requestBodies/document/createAttributes'
+          multipart/form-data:
+            schema:
+              allOf:
+                - $ref: '#/components/requestBodies/document/createAttributes'
+
+  /api/v1/shipments/{shipment_id}/documents/{document_id}/:
+    get:
+      summary: Get document details
+      description: |
+        Get additional info about a `Document`.
+
+        If `Document.upload_status` is `COMPLETE`, a presigned S3 URL for downloading the file will be included in the
+        `meta` payload.
+      parameters:
+        - $ref: '#/components/parameters/document/path'
+      tags:
+        - Documents
+      responses:
+        '200':
+          description: *response_200
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/document/getResponse'
+        '401':
+          description: *response_401
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/errors/401'
+
+    patch:
+      summary: Update a document
+      description: >
+        Update a `Document` object with the provided parameters.
+      tags:
+        - Documents
+      responses:
+        '202':
+          description: *response_202
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/document/getResponse'
+        '401':
+          description: *response_401
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/errors/401'
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/requestBodies/document/createRequest'
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/requestBodies/document/createAttributes'
+          multipart/form-data:
+            schema:
+              allOf:
+                - $ref: '#/components/requestBodies/document/createAttributes'
 
   /api/v1/shipments/{shipment_id}/transactions/:
     get:
@@ -316,132 +415,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/errors/401'
 
-
-  /api/v1/documents/:
-    get:
-      summary: List documents
-      description: >
-        Retrieve an array of `Document` objects associated with the current user.
-      parameters:
-      - $ref: '#/components/parameters/page'
-      - $ref: '#/components/parameters/page_size'
-      - $ref: '#/components/parameters/document/fileType'
-      - $ref: '#/components/parameters/document/documentType'
-      - $ref: '#/components/parameters/document/uploadStatus'
-      tags:
-      - Documents
-      responses:
-        '200':
-          description: *response_200
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/document/listResponse'
-        '401':
-          description: *response_401
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/errors/401'
-
-    post:
-      summary: Create document
-      description: |
-        Create a new `Document` owned by the current user.
-
-        A presigned S3 request will be generated with credentials to POST a new file of the specified type to S3.
-        Engine will then upload the file to the Shipment's vault.
-
-        Note: `Document.upload_status` will need to be updated to `COMPLETE` in order for the document to be retrieved
-        from S3.
-      tags:
-      - Documents
-      responses:
-        '202':
-          description: *response_202
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/document/createResponse'
-        '401':
-          description: *response_401
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/errors/401'
-      requestBody:
-        content:
-          application/vnd.api+json:
-            schema:
-              $ref: '#/components/requestBodies/document/createRequest'
-          application/json:
-            schema:
-              allOf:
-              - $ref: '#/components/requestBodies/document/createAttributes'
-          multipart/form-data:
-            schema:
-              allOf:
-              - $ref: '#/components/requestBodies/document/createAttributes'
-
-  /api/v1/documents/{document_id}/:
-    get:
-      summary: Get document details
-      description: |
-        Get additional info about a `Document`.
-
-        If `Document.upload_status` is `COMPLETE`, a presigned S3 URL for downloading the file will be included in the
-        `meta` payload.
-      parameters:
-      - $ref: '#/components/parameters/document/path'
-      tags:
-      - Documents
-      responses:
-        '200':
-          description: *response_200
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/document/getResponse'
-        '401':
-          description: *response_401
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/errors/401'
-
-    patch:
-      summary: Update a document
-      description: >
-        Update a `Document` object with the provided parameters.
-      tags:
-      - Documents
-      responses:
-        '202':
-          description: *response_202
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/document/getResponse'
-        '401':
-          description: *response_401
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/errors/401'
-      requestBody:
-        content:
-          application/vnd.api+json:
-            schema:
-              $ref: '#/components/requestBodies/document/createRequest'
-          application/json:
-            schema:
-              allOf:
-              - $ref: '#/components/requestBodies/document/createAttributes'
-          multipart/form-data:
-            schema:
-              allOf:
-              - $ref: '#/components/requestBodies/document/createAttributes'
-
   /api/v1/shipments/{shipment_id}/tracking/:
     post:
       summary: Add tracking data
@@ -494,8 +467,6 @@ paths:
         Retrieve GPS tracking data associated with a `Shipment` as a GeoJSON FeatureCollection of points (content returned in 'data' attribute conforms to the [GeoJSON](https://tools.ietf.org/html/rfc7946) spec).
       parameters:
       - $ref: '#/components/parameters/shipment/path'
-#      - $ref: '#/components/parameters/shipment/asPoint'
-#      - $ref: '#/components/parameters/shipment/asLine'
       tags:
       - Shipments
       responses:
@@ -506,8 +477,6 @@ paths:
               schema:
                 oneOf:
                 - $ref: '#/components/schemas/tracking/pointResponse'
-#                - $ref: '#/components/schemas/tracking/lineResponse'
-#                - $ref: '#/components/schemas/tracking/getResponse'
         '401':
           description: *response_401
           content:

--- a/apps/schema/static/schema/swagger.yaml
+++ b/apps/schema/static/schema/swagger.yaml
@@ -233,7 +233,7 @@ paths:
         '202':
           description: *response_202
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/document/createResponse'
         '401':

--- a/apps/schema/static/schema/swagger.yaml
+++ b/apps/schema/static/schema/swagger.yaml
@@ -3089,6 +3089,12 @@ components:
               data:
                 items:
                   $ref: '#/components/schemas/document/getResource'
+          - properties:
+              data:
+                items:
+                  properties:
+                    meta:
+                      $ref: '#/components/schemas/dataTypes/document/presignedS3Get'
 
     tracking:
       collectionResource:

--- a/apps/schema/static/schema/swagger.yaml
+++ b/apps/schema/static/schema/swagger.yaml
@@ -3481,7 +3481,6 @@ components:
 
       createAttributes:
         required:
-          - shipment_id
           - file_type
           - document_type
           - name
@@ -3491,8 +3490,6 @@ components:
           - $ref: '#/components/schemas/dataTypes/document/documentType'
           - $ref: '#/components/schemas/dataTypes/document/fileType'
           - $ref: '#/components/schemas/dataTypes/document/uploadStatus'
-          - $ref: '#/components/schemas/dataTypes/shipmentId'
-
 
       createRequest:
         allOf:

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -35,8 +35,8 @@ router.register(f'{API_PREFIX[1:]}/shipments', shipments.ShipmentViewSet)
 router.register(f'{API_PREFIX[1:]}/jobs', jobs.JobsViewSet, base_name='job')
 router.register(f'{API_PREFIX[1:]}/events', eth.EventViewSet, base_name='event')
 router.register(f'{API_PREFIX[1:]}/transactions', eth.TransactionViewSet, base_name='transaction')
-router.register(f'{API_PREFIX[1:]}/documents', documents.DocumentViewSet)
 
+# Shipment's nested routes definition
 nested_router = drf_nested_routers.NestedSimpleRouter(router, f'{API_PREFIX[1:]}/shipments', lookup='shipment')
 nested_router.register(r'documents', documents.DocumentViewSet, base_name='shipment-documents')
 nested_router.register(r'transactions', eth.TransactionViewSet, base_name='shipment-transactions')

--- a/tests/postman.collection.Transmission.json
+++ b/tests/postman.collection.Transmission.json
@@ -1073,7 +1073,7 @@
                     "path": [
                       "api",
                       "v1",
-                      "documents",
+                      "shipments",
                       "{{shipment_id}}",
                       "permission_links",
                       "{{permission_link_id}}",
@@ -1299,13 +1299,15 @@
                     ]
                   },
                   "url": {
-                    "raw": "{{transmission_url}}/api/v1/documents/",
+                    "raw": "{{transmission_url}}/api/v1/shipments/{shipment_id}/documents/",
                     "host": [
                       "{{transmission_url}}"
                     ],
                     "path": [
                       "api",
                       "v1",
+                      "shipments",
+                      "{{shipment_id}}",
                       "documents",
                       ""
                     ]
@@ -1325,13 +1327,15 @@
                   ],
                   "body": {},
                   "url": {
-                    "raw": "{{transmission_url}}/api/v1/documents/",
+                    "raw": "{{transmission_url}}/api/v1/shipments/{shipment_id}/documents/",
                     "host": [
                       "{{transmission_url}}"
                     ],
                     "path": [
                       "api",
                       "v1",
+                      "shipments",
+                      "{{shipment_id}}",
                       "documents",
                       ""
                     ]
@@ -1351,13 +1355,15 @@
                   ],
                   "body": {},
                   "url": {
-                    "raw": "{{transmission_url}}/api/v1/documents/{{document_id}}/",
+                    "raw": "{{transmission_url}}/api/v1/shipments/{shipment_id}/documents/{{document_id}}/",
                     "host": [
                       "{{transmission_url}}"
                     ],
                     "path": [
                       "api",
                       "v1",
+                      "shipments",
+                      "{{shipment_id}}",
                       "documents",
                       "{{document_id}}",
                       ""
@@ -1412,13 +1418,15 @@
                     ]
                   },
                   "url": {
-                    "raw": "{{transmission_url}}/api/v1/documents/{{document_id}}/",
+                    "raw": "{{transmission_url}}/api/v1/shipments/{shipment_id}/documents/{{document_id}}/",
                     "host": [
                       "{{transmission_url}}"
                     ],
                     "path": [
                       "api",
                       "v1",
+                      "shipments",
+                      "{{shipment_id}}",
                       "documents",
                       "{{document_id}}",
                       ""

--- a/tests/profiles-enabled/test_documents.py
+++ b/tests/profiles-enabled/test_documents.py
@@ -436,19 +436,6 @@ class DocumentAPITests(APITestCase):
             self.assertEqual(mock_is_carrier.call_count, 0)
             self.assertEqual(mock_is_moderator.call_count, 0)
 
-        # trying to create a document with a shipment_id, different than the one included in the url should failed
-        url = reverse('shipment-documents-list', kwargs={'version': 'v1', 'shipment_pk': self.shipments[0].id})
-        self.set_user(self.user_1)
-        file_data, content_type = create_form_content({
-            'name': 'Wrong Shipment_id',
-            'document_type': 'Bol',
-            'file_type': 'Pdf',
-            'shipment_id': self.shipments[1].id
-        })
-
-        response = self.client.post(url, file_data, content_type=content_type)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
 
 class ImageDocumentViewSetAPITests(APITestCase):
 

--- a/tests/profiles-enabled/test_documents.py
+++ b/tests/profiles-enabled/test_documents.py
@@ -436,6 +436,19 @@ class DocumentAPITests(APITestCase):
             self.assertEqual(mock_is_carrier.call_count, 0)
             self.assertEqual(mock_is_moderator.call_count, 0)
 
+        # trying to create a document with a shipment_id, different than the one included in the url should failed
+        url = reverse('shipment-documents-list', kwargs={'version': 'v1', 'shipment_pk': self.shipments[0].id})
+        self.set_user(self.user_1)
+        file_data, content_type = create_form_content({
+            'name': 'Wrong Shipment_id',
+            'document_type': 'Bol',
+            'file_type': 'Pdf',
+            'shipment_id': self.shipments[1].id
+        })
+
+        response = self.client.post(url, file_data, content_type=content_type)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class ImageDocumentViewSetAPITests(APITestCase):
 

--- a/tests/profiles-enabled/test_documents.py
+++ b/tests/profiles-enabled/test_documents.py
@@ -23,6 +23,7 @@ from tests.utils import create_form_content, get_jwt
 
 SHIPMENT_ID = 'Shipment-Custom-Id-{}'
 FAKE_ID = '00000000-0000-0000-0000-000000000000'
+OWNER_ID = '5e8f1d76-162d-4f21-9b71-2ca97306ef7c'
 SHIPPER_ID = '60b2662a-4ec6-4c28-ac1b-2b82ab4b3e03'
 CARRIER_ID = 'ff7908cd-6b10-43a7-9fa2-760c4b17dab4'
 MODERATOR_ID = '6eeff71e-332e-40e0-8961-f74dab3ff8e0'
@@ -44,7 +45,7 @@ class PdfDocumentViewSetAPITests(APITestCase):
         # Disable Shipment post save signal
         signals.post_save.disconnect(sender=Shipment, dispatch_uid='shipment_post_save')
 
-        self.user_1 = passive_credentials_auth(get_jwt(username='user1@shipchain.io'))
+        self.user_1 = passive_credentials_auth(get_jwt(username='user1@shipchain.io', sub=OWNER_ID))
 
         self.shipment = Shipment.objects.create(
             id=SHIPMENT_ID,
@@ -52,7 +53,7 @@ class PdfDocumentViewSetAPITests(APITestCase):
             carrier_wallet_id=CARRIER_WALLET_ID,
             shipper_wallet_id=SHIPPER_WALLET_ID,
             storage_credentials_id=STORAGE_CRED_ID,
-            owner_id='5e8f1d76-162d-4f21-9b71-2ca97306ef7c'
+            owner_id=OWNER_ID
         )
 
         # Re-enable Shipment post save signal
@@ -88,11 +89,14 @@ class PdfDocumentViewSetAPITests(APITestCase):
         pdf.cell(40, 60, f"{DATE}")
         pdf.output(file_path, 'F')
 
+    @mock.patch('apps.documents.permissions.UserHasPermission.is_shipper', mock.MagicMock(return_value=False))
+    @mock.patch('apps.documents.permissions.UserHasPermission.is_carrier', mock.MagicMock(return_value=False))
+    @mock.patch('apps.documents.permissions.UserHasPermission.is_moderator', mock.MagicMock(return_value=False))
     def test_sign_to_s3(self):
         mock_document_rpc_client = DocumentRPCClient
         mock_document_rpc_client.put_document_in_s3 = mock.Mock(return_value=True)
 
-        url = reverse('document-list', kwargs={'version': 'v1'})
+        url = reverse('shipment-documents-list', kwargs={'version': 'v1', 'shipment_pk': self.shipment.id})
 
         f_path = './tests/tmp/test_upload.pdf'
         self.make_pdf_file(f_path)
@@ -107,7 +111,7 @@ class PdfDocumentViewSetAPITests(APITestCase):
 
         # Unauthenticated user should fail
         response = self.client.post(url, file_data, content_type=content_type)
-        self.assertNotEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         # Authenticated request should succeed
         self.set_user(self.user_1)
@@ -143,26 +147,26 @@ class PdfDocumentViewSetAPITests(APITestCase):
         self.assertTrue(downloaded_file.exists())
 
         # Update document object upon upload completion
-        url = reverse('document-detail', kwargs={'version': 'v1', 'pk': document[0].id})
+        url_patch = url + f'{document[0].id}/'
         file_data, content_type = create_form_content({
             'upload_status': 'COMPLETE',
         })
-        response = self.client.patch(url, file_data, content_type=content_type)
+        response = self.client.patch(url_patch, file_data, content_type=content_type)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(document[0].upload_status, UploadStatus.COMPLETE)
 
-        # # Tentative to update a fields other than upload_status should fail
+        # Tentative to update a fields other than upload_status should fail
         file_data, content_type = create_form_content({
             'document_type': DocumentType.IMAGE,
             'shipment_id': self.shipment.id,
         })
-        response = self.client.patch(url, file_data, content_type=content_type)
+        response = self.client.patch(url_patch, file_data, content_type=content_type)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotEqual(document[0].document_type, DocumentType.IMAGE)
 
         # Get a document
-        url = reverse('document-detail', kwargs={'version': 'v1', 'pk': document[0].id})
-        response = self.client.get(url)
+        url_get = url + f'{document[0].id}/'
+        response = self.client.get(url_get)
         data = response.json()['data']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -182,56 +186,51 @@ class PdfDocumentViewSetAPITests(APITestCase):
             'file_type': 'Pdf',
             'shipment_id': self.shipment.id
         })
-        url = reverse('document-list', kwargs={'version': 'v1'})
+
         response = self.client.post(url, file_data, content_type=content_type)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        document = Document.objects.all()
+        document = Document.objects.all().order_by('created_at')
         self.assertEqual(document.count(), 2)
 
         # Update second uploaded document status to complete
-        url = reverse('document-detail', kwargs={'version': 'v1', 'pk': document[1].id})
+        url_patch = url + f'{document[1].id}/'
         file_data, content_type = create_form_content({
             'upload_status': 'Complete',
         })
-        response = self.client.patch(url, file_data, content_type=content_type)
+        response = self.client.patch(url_patch, file_data, content_type=content_type)
         data = response.json()['data']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(document[1].upload_status, UploadStatus.COMPLETE)
         self.assertTrue(isinstance(data['meta']['presigned_s3'], str))
 
         # Get list of documents
-        url = reverse('document-list', kwargs={'version': 'v1'})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Get list of pdf documents via query params, it should return 2 elements
-        url = reverse('document-list', kwargs={'version': 'v1'})
-        url += f'?file_type=Pdf'
-        response = self.client.get(url)
+        url_pdf = url + '?file_type=Pdf'
+        response = self.client.get(url_pdf)
         data = response.json()['data']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data), 2)
 
         # Querying for png files should return an empty list at this stage
-        url = reverse('document-list', kwargs={'version': 'v1'})
-        url += f'?file_type=Png'
-        response = self.client.get(url)
+        url_png = url + '?file_type=Png'
+        response = self.client.get(url_png)
         data = response.json()['data']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data), 0)
 
         # Get list of BOL documents via query params, it should return 2 elements
-        url = reverse('document-list', kwargs={'version': 'v1'})
-        url += f'?document_type=Bol'
-        response = self.client.get(url)
+        url_bol = url + '?document_type=Bol'
+        response = self.client.get(url_bol)
         data = response.json()['data']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data), 2)
 
         # Querying for file objects with upload_status FAILED, should return an empty list at this stage
-        url = reverse('document-list', kwargs={'version': 'v1'})
-        url += f'?upload_status=FAIled'
-        response = self.client.get(url)
+        url_failed_satus = url + '?upload_status=FAIled'
+        response = self.client.get(url_failed_satus)
         data = response.json()['data']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data), 0)
@@ -446,7 +445,7 @@ class ImageDocumentViewSetAPITests(APITestCase):
         # Disable Shipment post save signal
         signals.post_save.disconnect(sender=Shipment, dispatch_uid='shipment_post_save')
 
-        self.user_1 = passive_credentials_auth(get_jwt(username='user1@shipchain.io'))
+        self.user_1 = passive_credentials_auth(get_jwt(username='user1@shipchain.io', sub=OWNER_ID))
 
         self.shipment = Shipment.objects.create(
             id=SHIPMENT_ID,
@@ -454,7 +453,7 @@ class ImageDocumentViewSetAPITests(APITestCase):
             carrier_wallet_id=CARRIER_WALLET_ID,
             shipper_wallet_id=SHIPPER_WALLET_ID,
             storage_credentials_id=STORAGE_CRED_ID,
-            owner_id='5e8f1d76-162d-4f21-9b71-2ca97306ef7c'
+            owner_id=OWNER_ID
         )
 
         # Re-enable Shipment post save signal
@@ -493,13 +492,16 @@ class ImageDocumentViewSetAPITests(APITestCase):
         draw.text((160, 150), DATE, font=font2, fill='white')
         img.save(file_path)
 
+    @mock.patch('apps.documents.permissions.UserHasPermission.is_shipper', mock.MagicMock(return_value=False))
+    @mock.patch('apps.documents.permissions.UserHasPermission.is_carrier', mock.MagicMock(return_value=False))
+    @mock.patch('apps.documents.permissions.UserHasPermission.is_moderator', mock.MagicMock(return_value=False))
     def test_image_creation(self):
         img_path = ['./tests/tmp/jpeg_img.jpg', './tests/tmp/png_img.png']
 
         for img in img_path:
             self.make_image(img)
 
-        url = reverse('document-list', kwargs={'version': 'v1'})
+        url = reverse('shipment-documents-list', kwargs={'version': 'v1', 'shipment_pk': self.shipment.id})
 
         file_data, content_type = create_form_content({
             'name': os.path.basename(img_path[1]),
@@ -528,32 +530,32 @@ class ImageDocumentViewSetAPITests(APITestCase):
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
 
         # Failed upload document and Pending should have the presigned post meta object
-        url = reverse('document-detail', kwargs={'version': 'v1', 'pk': document[0].id})
+        url_patch = url + f'{document[0].id}/'
         file_data, content_type = create_form_content({
             'upload_status': 'Failed',
         })
-        response = self.client.patch(url, file_data, content_type=content_type)
-        data = response.json()['data']
+        response = self.client.patch(url_patch, file_data, content_type=content_type)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()['data']
         self.assertEqual(document[0].upload_status, UploadStatus.FAILED)
         self.assertTrue(isinstance(data['meta']['presigned_s3'], dict))
 
         # Update document object upon upload completion
-        url = reverse('document-detail', kwargs={'version': 'v1', 'pk': document[0].id})
         file_data, content_type = create_form_content({
             'upload_status': 'complete',
         })
-        response = self.client.patch(url, file_data, content_type=content_type)
-        data = response.json()['data']
+        response = self.client.patch(url_patch, file_data, content_type=content_type)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()['data']
         self.assertEqual(document[0].upload_status, UploadStatus.COMPLETE)
         self.assertTrue(isinstance(data['meta']['presigned_s3'], str))
 
         # Get a document
-        url = reverse('document-detail', kwargs={'version': 'v1', 'pk': document[0].id})
-        response = self.client.get(url)
-        data = response.json()['data']
+        # url = reverse('document-detail', kwargs={'version': 'v1', 'pk': document[0].id})
+        url_get = url + f'{document[0].id}/'
+        response = self.client.get(url_get)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()['data']
         self.assertTrue(data['meta']['presigned_s3'])
 
         # Download document from pre-signed s3 generated url
@@ -563,27 +565,29 @@ class ImageDocumentViewSetAPITests(APITestCase):
             f.write(res.content)
 
         # Get list of png image via query params, should return one document
-        url = reverse('document-list', kwargs={'version': 'v1'})
-        url += '?file_type=Png'
-        response = self.client.get(url)
-        data = response.json()['data']
+        url_png = url + '?file_type=Png'
+        response = self.client.get(url_png)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()['data']
         self.assertEqual(len(data), 1)
 
         # This should return an empty list since there is no pdf in db at this stage
-        url = reverse('document-list', kwargs={'version': 'v1'})
-        url += '?file_type=Pdf'
-        response = self.client.get(url)
+        url_pdf = url + '?file_type=Pdf'
+        response = self.client.get(url_pdf)
         data = response.json()['data']
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data), 0)
 
+    @mock.patch('apps.documents.permissions.UserHasPermission.is_shipper', mock.MagicMock(return_value=False))
+    @mock.patch('apps.documents.permissions.UserHasPermission.is_carrier', mock.MagicMock(return_value=False))
+    @mock.patch('apps.documents.permissions.UserHasPermission.is_moderator', mock.MagicMock(return_value=False))
     def test_get_document_from_vault(self):
         img_path = './tests/tmp/png_img.png'
 
         self.make_image(img_path)
 
-        url = reverse('document-list', kwargs={'version': 'v1'})
+        # url = reverse('document-list', kwargs={'version': 'v1'})
+        url = reverse('shipment-documents-list', kwargs={'version': 'v1', 'shipment_pk': self.shipment.id})
 
         file_data, content_type = create_form_content({
             'name': os.path.basename(img_path),
@@ -655,15 +659,16 @@ class ImageDocumentViewSetAPITests(APITestCase):
 
         # Trying to access the COMPLETE document detail the rpc method should be called
         mock_document_rpc_client.put_document_in_s3.reset_mock()
-        url = reverse('document-detail', kwargs={'version': 'v1', 'pk': doc.id})
-        response = self.client.patch(url, {}, content_type='application/json')
+        # url = reverse('document-detail', kwargs={'version': 'v1', 'pk': doc.id})
+        url_get = url + f'{doc.id}/'
+        response = self.client.patch(url_get, {}, content_type='application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_document_rpc_client.put_document_in_s3.assert_called_once()
 
         # In case of rpc error, we should have a null presigned_url
         mock_document_rpc_client.put_document_in_s3 = mock.Mock(return_value=False)
-        url = reverse('document-detail', kwargs={'version': 'v1', 'pk': doc.id})
-        response = self.client.get(url)
+        # url = reverse('document-detail', kwargs={'version': 'v1', 'pk': doc.id})
+        response = self.client.get(url_get)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()['data']
         self.assertIsNone(data['meta']['presigned_s3'])

--- a/tests/profiles-enabled/test_documents.py
+++ b/tests/profiles-enabled/test_documents.py
@@ -105,8 +105,7 @@ class PdfDocumentViewSetAPITests(APITestCase):
             'name': 'Test BOL',
             'description': 'Auto generated file for test purposes',
             'document_type': 'Bol',
-            'file_type': 'Pdf',
-            'shipment_id': self.shipment.id
+            'file_type': 'Pdf'
         })
 
         # Unauthenticated user should fail
@@ -158,7 +157,6 @@ class PdfDocumentViewSetAPITests(APITestCase):
         # Tentative to update a fields other than upload_status should fail
         file_data, content_type = create_form_content({
             'document_type': DocumentType.IMAGE,
-            'shipment_id': self.shipment.id,
         })
         response = self.client.patch(url_patch, file_data, content_type=content_type)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -183,8 +181,7 @@ class PdfDocumentViewSetAPITests(APITestCase):
         file_data, content_type = create_form_content({
             'name': os.path.basename(f_path),
             'document_type': 'Bol',
-            'file_type': 'Pdf',
-            'shipment_id': self.shipment.id
+            'file_type': 'Pdf'
         })
 
         response = self.client.post(url, file_data, content_type=content_type)
@@ -354,8 +351,7 @@ class DocumentAPITests(APITestCase):
         file_data = {
             'name': 'Test Permission',
             'document_type': 'Image',
-            'file_type': 'Png',
-            'shipment_id': self.shipments[0].id
+            'file_type': 'Png'
         }
 
         self.set_user(self.user_1)
@@ -506,8 +502,7 @@ class ImageDocumentViewSetAPITests(APITestCase):
         file_data, content_type = create_form_content({
             'name': os.path.basename(img_path[1]),
             'document_type': 'Image',
-            'file_type': 'Png',
-            'shipment_id': self.shipment.id
+            'file_type': 'Png'
         })
 
         # png image object creation
@@ -592,8 +587,7 @@ class ImageDocumentViewSetAPITests(APITestCase):
         file_data, content_type = create_form_content({
             'name': os.path.basename(img_path),
             'document_type': 'Image',
-            'file_type': 'Png',
-            'shipment_id': self.shipment.id
+            'file_type': 'Png'
         })
 
         mock_document_rpc_client = DocumentRPCClient


### PR DESCRIPTION
With this PR, the base shipment's documents enpoint has been changed from `/api/v1/documents/` to `/api/v1/shipments/{shipment_id}/documents/`. The old endpoint has been deleted altogether and once approved, the documents `creation` and `update` will be performed respectively on:
- `/api/v1/shipments/{shipment_id}/documents/`
- `/api/v1/shipments/{shipment_id}/documents/{document_id}/`
The Swagger documentation has been updated to reflect these changes as well as the postman collection