### PR TITLE
Remove device from shipment upon delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Once the dependencies are resolved, starting Transmission should be as easy as:
 
 By default, the [dev.yml](bin/dev.yml) compose file uses Django runserver, which is mapped to the host port 8000.
 
+In addition, you are able to see the current Celery tasks when running locally, which is mapped to the port 8888.
+
 ### Authentication
 All endpoints require a valid JWT from OIDC Auth with the ShipChain Profiles service. The JWT shall
 be provided to Transmission as a bearer token in the `Authorization` request header, in the format

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Once the dependencies are resolved, starting Transmission should be as easy as:
 
 By default, the [dev.yml](bin/dev.yml) compose file uses Django runserver, which is mapped to the host port 8000.
 
-In addition, you are able to see the current Celery tasks when running locally through Flower, which is mapped to the port 8888.
+In addition, you are able to see the current Celery tasks when running locally through Flower, which is mapped to the host port 8888.
 
 ### Authentication
 All endpoints require a valid JWT from OIDC Auth with the ShipChain Profiles service. The JWT shall

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Once the dependencies are resolved, starting Transmission should be as easy as:
 
 By default, the [dev.yml](bin/dev.yml) compose file uses Django runserver, which is mapped to the host port 8000.
 
-In addition, you are able to see the current Celery tasks when running locally, which is mapped to the port 8888.
+In addition, you are able to see the current Celery tasks when running locally through Flower, which is mapped to the port 8888.
 
 ### Authentication
 All endpoints require a valid JWT from OIDC Auth with the ShipChain Profiles service. The JWT shall

--- a/apps/schema/static/schema/swagger.yaml
+++ b/apps/schema/static/schema/swagger.yaml
@@ -1741,7 +1741,7 @@ components:
           properties:
             delivery_act:
               title: delivery_act
-              description: Actual timestamp of delivery
+              description: Actual timestamp of delivery, cannot be set to a time in the future
               type: string
               example: '2018-08-22T17:44:39.874352'
 

--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -226,6 +226,11 @@ class ShipmentUpdateSerializer(ShipmentSerializer):
 
         return device_id
 
+    def validate_delivery_act(self, delivery_act):
+        if delivery_act <= datetime.now():
+            return delivery_act
+        raise serializers.ValidationError('Cannot update Shipment with future delivery_act')
+
 
 class PermissionLinkSerializer(serializers.ModelSerializer):
     shipment_id = serializers.CharField(max_length=36, required=False)

--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -121,8 +121,9 @@ def trackingdata_post_save(sender, **kwargs):
 def shipment_delivery_act_changed(sender, instance, changed_fields, **kwargs):
     logging.info(f'Shipment with id {instance.id} ended on {instance.delivery_act}.')
 
-    instance.device = None
-    instance.save()
+    device_id = instance.device_id
+    Shipment.objects.filter(id=instance.id).update(device_id=None)
+    shipment_device_id_changed(Shipment, instance, {Shipment.device.field: (device_id, None)})
 
 
 @receiver(post_save_changed, sender=Shipment, fields=['device'], dispatch_uid='shipment_device_id_post_save')

--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
@@ -120,11 +119,10 @@ def trackingdata_post_save(sender, **kwargs):
 
 @receiver(post_save_changed, sender=Shipment, fields=['delivery_act'], dispatch_uid='shipment_delivery_act_post_save')
 def shipment_delivery_act_changed(sender, instance, changed_fields, **kwargs):
-    if instance.delivery_act <= datetime.now():
-        logging.info(f'Shipment with id {instance.id} ended on {instance.delivery_act}.')
+    logging.info(f'Shipment with id {instance.id} ended on {instance.delivery_act}.')
 
-        instance.device = None
-        instance.save()
+    instance.device = None
+    instance.save()
 
 
 @receiver(post_save_changed, sender=Shipment, fields=['device'], dispatch_uid='shipment_device_id_post_save')

--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
@@ -115,6 +116,15 @@ def trackingdata_post_save(sender, **kwargs):
     LOG.debug(f'New tracking_data committed to db and will be pushed to the UI. Tracking_data: {instance.id}.')
     async_to_sync(channel_layer.group_send)(instance.shipment.owner_id,
                                             {"type": "tracking_data.save", "tracking_data_id": instance.id})
+
+
+@receiver(post_save_changed, sender=Shipment, fields=['delivery_act'], dispatch_uid='shipment_delivery_act_post_save')
+def shipment_delivery_act_changed(sender, instance, changed_fields, **kwargs):
+    if instance.delivery_act <= datetime.now():
+        logging.info(f'Shipment with id {instance.id} ended on {instance.delivery_act}.')
+
+        instance.device = None
+        instance.save()
 
 
 @receiver(post_save_changed, sender=Shipment, fields=['device'], dispatch_uid='shipment_device_id_post_save')

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -128,6 +128,17 @@ services:
       - FORCE_DEBUG
     entrypoint: []
 
+  flower:
+    image: mher/flower
+    command: ["flower", "--broker=redis://:redis_pass@redis_db:6379/1", "--port=8888"]
+    environment:
+      - CELERYBROKER_URL=redis://redis:6379/0
+      - SERVICE=flower
+    ports:
+      - 8888:8888
+    links:
+      - celery
+      - redis_db
 networks:
   portal:
     external: true

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -1558,11 +1558,12 @@ class ShipmentWithIoTAPITests(APITestCase):
             shipment_obj.refresh_from_db()
             shipment_obj.delivery_act = datetime.now()
             shipment_obj.save()
+            shipment_obj.refresh_from_db()
 
             self.assertIsNone(shipment_obj.device)
             response = self.create_shipment()
             assert response.status_code == status.HTTP_202_ACCEPTED
-            mocked_call_count += 2
+            mocked_call_count += 4
             assert mocked.call_count == mocked_call_count
 
             response_json = response.json()

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -1543,14 +1543,15 @@ class ShipmentWithIoTAPITests(APITestCase):
             assert response.status_code == status.HTTP_400_BAD_REQUEST
             assert mocked.call_count == mocked_call_count
 
-            # Devices can be reused after deliveries are complete
+            # Devices can be reused after deliveries are complete and should be removed from old shipment
             shipment_obj.refresh_from_db()
             shipment_obj.delivery_act = datetime.now()
             shipment_obj.save()
 
+            self.assertIsNone(shipment_obj.device)
             response = self.create_shipment()
             assert response.status_code == status.HTTP_202_ACCEPTED
-            mocked_call_count += 1
+            mocked_call_count += 2
             assert mocked.call_count == mocked_call_count
 
             response_json = response.json()


### PR DESCRIPTION
When a shipment's ended, as noted by delivery_act, it is helpful to automatically remove the delivery_act from the shipment. This push causes this to happen when the delivery_act is updated on the shipment, and is a before or equal to datetime.now. This ensures that it will only be removed if the shipment has been delivered.