### PR TITLE
Shipment transactions via permission link

### DIFF
--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -80,8 +80,7 @@ class TransactionViewSet(mixins.RetrieveModelMixin,
     """
     queryset = EthAction.objects.all()
     serializer_class = EthActionSerializer
-    permission_classes = ((permissions.IsAuthenticated, IsListenerOwner) if settings.PROFILES_ENABLED
-                          else (permissions.AllowAny,))
+    permission_classes = ((IsListenerOwner, ) if settings.PROFILES_ENABLED else (permissions.AllowAny, ))
 
     def get_queryset(self):
         log_metric('transmission.info', tags={'method': 'transaction.get_queryset', 'module': __name__})

--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -105,9 +105,7 @@ class TransactionViewSet(mixins.RetrieveModelMixin,
         log_metric('transmission.info', tags={'method': 'transaction.list', 'module': __name__})
 
         shipment_pk = kwargs.get('shipment_pk', None)
-        permission_link = request.query_params.get('permission_link', None)
-
-        if shipment_pk and permission_link or shipment_pk:
+        if shipment_pk:
             LOG.debug(f'Getting transactions for shipment: {shipment_pk}.')
 
             queryset = self.queryset.filter(ethlistener__shipments__id=shipment_pk)

--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -106,7 +106,9 @@ class TransactionViewSet(mixins.RetrieveModelMixin,
         log_metric('transmission.info', tags={'method': 'transaction.list', 'module': __name__})
 
         shipment_pk = kwargs.get('shipment_pk', None)
-        if shipment_pk:
+        permission_link = request.query_params.get('permission_link', None)
+
+        if shipment_pk and permission_link or shipment_pk:
             LOG.debug(f'Getting transactions for shipment: {shipment_pk}.')
 
             queryset = self.queryset.filter(ethlistener__shipments__id=shipment_pk)

--- a/apps/schema/static/schema/swagger.yaml
+++ b/apps/schema/static/schema/swagger.yaml
@@ -323,6 +323,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/page_size'
+        - $ref: '#/components/parameters/transaction/permissionLinkId'
         - $ref: '#/components/parameters/transaction/include_async_job_action'
       tags:
         - Shipments
@@ -816,6 +817,13 @@ components:
           type: string
           enum:
             - async_job.actions
+
+      permissionLinkId:
+        name: permission_link
+        in: query
+        description: When included and valid, a permission link parameter provides unauthenticated read-only access to the shipment's transactions.
+        schema:
+          $ref: '#/components/schemas/dataTypes/uuid'
 
     document:
       path:

--- a/apps/shipments/permissions.py
+++ b/apps/shipments/permissions.py
@@ -1,13 +1,24 @@
-from django.conf import settings
+"""
+Copyright 2019 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from django.core.exceptions import ObjectDoesNotExist
-from rest_framework import permissions, status
+from rest_framework import permissions
 
-from apps.authentication import get_jwt_from_request
-from apps.permissions import has_owner_access
-from .models import PermissionLink, Shipment
-
-
-PROFILES_URL = f'{settings.PROFILES_URL}/api/v1/wallet'
+from apps.permissions import has_owner_access, check_has_shipment_owner_access, shipment_exists, check_permission_link
+from .models import PermissionLink
 
 
 class IsShipmentOwner(permissions.BasePermission):
@@ -108,69 +119,3 @@ class IsAuthenticatedOrDevice(permissions.IsAuthenticated):
             return True
 
         return super(IsAuthenticatedOrDevice, self).has_permission(request, view)
-
-
-def is_carrier(request, shipment):
-    """
-    Custom permission for carrier shipment access
-    """
-    response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.carrier_wallet_id}/?is_active',
-                                             headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
-
-    return response.status_code == status.HTTP_200_OK and request.method in ('GET', 'PATCH')
-
-
-def is_moderator(request, shipment):
-    """
-    Custom permission for moderator shipment access
-    """
-    if shipment.moderator_wallet_id:
-        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.moderator_wallet_id}/?is_active',
-                                                 headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
-
-        return response.status_code == status.HTTP_200_OK and request.method in ('GET', 'PATCH')
-
-    return False
-
-
-def is_shipper(request, shipment):
-    """
-    Custom permission for shipper shipment access
-    """
-    response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.shipper_wallet_id}/?is_active',
-                                             headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
-
-    return response.status_code == status.HTTP_200_OK and request.method in ('GET', 'PATCH')
-
-
-def shipment_exists(shipment_id):
-    """
-    Check whether a shipment_id included in a nested route exists.
-    Returns False if it isn't otherwise returns the Shipment object
-    """
-    try:
-        shipment_obj = Shipment.objects.get(pk=shipment_id)
-    except ObjectDoesNotExist:
-        return False
-
-    return shipment_obj
-
-
-def check_permission_link(request, shipment_obj):
-    permission_link_id = request.query_params.get('permission_link', None)
-    if permission_link_id:
-        try:
-            permission_obj = PermissionLink.objects.get(pk=permission_link_id)
-        except ObjectDoesNotExist:
-            return False
-        if not permission_obj.is_valid:
-            return check_has_shipment_owner_access(request, shipment_obj)
-
-        return shipment_obj.pk == permission_obj.shipment.pk and request.method == 'GET'
-
-    return check_has_shipment_owner_access(request, shipment_obj)
-
-
-def check_has_shipment_owner_access(request, obj):
-    return request.user.is_authenticated and (has_owner_access(request, obj) or is_shipper(request, obj) or
-                                              is_carrier(request, obj) or is_moderator(request, obj))

--- a/apps/shipments/permissions.py
+++ b/apps/shipments/permissions.py
@@ -49,7 +49,7 @@ class IsListenerOwner(permissions.BasePermission):
             return check_permission_link(request, shipment)
 
         # Transactions are still accessible on their own endpoint
-        return True
+        return request.user.is_authenticated
 
     def has_object_permission(self, request, view, obj):
         # Permissions are allowed to anyone who owns a shipment listening to this job

--- a/tests/profiles-enabled/test_documents.py
+++ b/tests/profiles-enabled/test_documents.py
@@ -89,9 +89,9 @@ class PdfDocumentViewSetAPITests(APITestCase):
         pdf.cell(40, 60, f"{DATE}")
         pdf.output(file_path, 'F')
 
-    @mock.patch('apps.documents.permissions.UserHasPermission.is_shipper', mock.MagicMock(return_value=False))
-    @mock.patch('apps.documents.permissions.UserHasPermission.is_carrier', mock.MagicMock(return_value=False))
-    @mock.patch('apps.documents.permissions.UserHasPermission.is_moderator', mock.MagicMock(return_value=False))
+    @mock.patch('apps.permissions.is_shipper', mock.MagicMock(return_value=False))
+    @mock.patch('apps.permissions.is_carrier', mock.MagicMock(return_value=False))
+    @mock.patch('apps.permissions.is_moderator', mock.MagicMock(return_value=False))
     def test_sign_to_s3(self):
         mock_document_rpc_client = DocumentRPCClient
         mock_document_rpc_client.put_document_in_s3 = mock.Mock(return_value=True)
@@ -362,9 +362,9 @@ class DocumentAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data), 4)
 
-        with mock.patch('apps.documents.permissions.UserHasPermission.is_shipper') as mock_is_shipper, \
-            mock.patch('apps.documents.permissions.UserHasPermission.is_carrier') as mock_is_carrier, \
-            mock.patch('apps.documents.permissions.UserHasPermission.is_moderator') as mock_is_moderator:
+        with mock.patch('apps.permissions.is_shipper') as mock_is_shipper, \
+            mock.patch('apps.permissions.is_carrier') as mock_is_carrier, \
+            mock.patch('apps.permissions.is_moderator') as mock_is_moderator:
             mock_is_shipper.return_value = True
             mock_is_carrier.return_value = False
             mock_is_moderator.return_value = False
@@ -488,9 +488,9 @@ class ImageDocumentViewSetAPITests(APITestCase):
         draw.text((160, 150), DATE, font=font2, fill='white')
         img.save(file_path)
 
-    @mock.patch('apps.documents.permissions.UserHasPermission.is_shipper', mock.MagicMock(return_value=False))
-    @mock.patch('apps.documents.permissions.UserHasPermission.is_carrier', mock.MagicMock(return_value=False))
-    @mock.patch('apps.documents.permissions.UserHasPermission.is_moderator', mock.MagicMock(return_value=False))
+    @mock.patch('apps.permissions.is_shipper', mock.MagicMock(return_value=False))
+    @mock.patch('apps.permissions.is_carrier', mock.MagicMock(return_value=False))
+    @mock.patch('apps.permissions.is_moderator', mock.MagicMock(return_value=False))
     def test_image_creation(self):
         img_path = ['./tests/tmp/jpeg_img.jpg', './tests/tmp/png_img.png']
 
@@ -573,9 +573,9 @@ class ImageDocumentViewSetAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data), 0)
 
-    @mock.patch('apps.documents.permissions.UserHasPermission.is_shipper', mock.MagicMock(return_value=False))
-    @mock.patch('apps.documents.permissions.UserHasPermission.is_carrier', mock.MagicMock(return_value=False))
-    @mock.patch('apps.documents.permissions.UserHasPermission.is_moderator', mock.MagicMock(return_value=False))
+    @mock.patch('apps.permissions.is_shipper', mock.MagicMock(return_value=False))
+    @mock.patch('apps.permissions.is_carrier', mock.MagicMock(return_value=False))
+    @mock.patch('apps.permissions.is_moderator', mock.MagicMock(return_value=False))
     def test_get_document_from_vault(self):
         img_path = './tests/tmp/png_img.png'
 

--- a/tests/profiles-enabled/test_eth.py
+++ b/tests/profiles-enabled/test_eth.py
@@ -10,7 +10,7 @@ from rest_framework.test import APITestCase, APIClient, force_authenticate
 from apps.authentication import passive_credentials_auth
 from apps.eth.models import TransactionReceipt, EthAction
 from apps.jobs.models import AsyncJob
-from apps.shipments.models import Shipment
+from apps.shipments.models import Shipment, PermissionLink
 from apps.shipments.rpc import Load110RPCClient
 from tests.utils import get_jwt
 


### PR DESCRIPTION
- Add ability to get a shipment's transactions via permission link
- Refactor `shipments.permissions` and `documents.permissions` in `DRY` optic.
- Add shipment transactions permission link tests.