### PR TITLE
Add tracking data permission link tests

### DIFF
--- a/apps/shipments/permissions.py
+++ b/apps/shipments/permissions.py
@@ -82,7 +82,7 @@ class IsOwnerOrShared(permissions.IsAuthenticated):
     def has_permission(self, request, view):
 
         permission_link = request.query_params.get('permission_link', None)
-        shipment_pk = request.parser_context['kwargs'].get('pk', None)
+        shipment_pk = view.kwargs.get('pk', None) or view.kwargs.get('shipment_pk', None)
 
         # The shipments can only be accessible via permission link only on shipment-detail endpoint
         if permission_link and not shipment_pk:


### PR DESCRIPTION
This PR adds the tracking data permission link tests and make sure that both the shipment `pk` and `shipment_pk` respectively from `shipment-detail` and shipment nested routes, are retrieved in the permission class.