### PR TITLE
Events processing reliability improvements

### DIFF
--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -122,7 +122,7 @@ class AsyncTask:
              retry_backoff=3, retry_backoff_max=60, max_retries=10)
 def async_job_fire(self):
     # Lock on Task ID to protect against tasks that are queued multiple times
-    task_lock = cache.lock(self.request.id)
+    task_lock = cache.lock(self.request.id, timeout=600)
     if task_lock.acquire(blocking=False):
         try:
             async_job_id = self.request.id

--- a/apps/shipments/rpc.py
+++ b/apps/shipments/rpc.py
@@ -1,6 +1,7 @@
 import logging
 
 from abc import abstractmethod
+from django.conf import settings
 from django.core.cache import cache
 from influxdb_metrics.loader import log_metric
 
@@ -33,7 +34,7 @@ class ShipmentRPCClient(RPCClient):
         raise RPCError("Invalid response from Engine")
 
     def add_shipment_data(self, storage_credentials_id, wallet_id, vault_id, shipment_data):
-        with cache.lock(vault_id):
+        with cache.lock(vault_id, timeout=settings.VAULT_TIMEOUT):
             LOG.debug(f'Adding shipment data with storage_credentials_id {storage_credentials_id},'
                       f'wallet_id {wallet_id}, and vault_id {vault_id}.')
             log_metric('transmission.info', tags={'method': 'shipment_rpcclient.add_shipment_data',
@@ -56,7 +57,7 @@ class ShipmentRPCClient(RPCClient):
             raise RPCError("Invalid response from Engine")
 
     def add_tracking_data(self, storage_credentials_id, wallet_id, vault_id, tracking_data):
-        with cache.lock(vault_id):
+        with cache.lock(vault_id, timeout=settings.VAULT_TIMEOUT):
             LOG.debug(f'Adding tracking data with storage_credentials_id {storage_credentials_id},'
                       f'wallet_id {wallet_id}, and vault_id {vault_id}.')
             log_metric('transmission.info', tags={'method': 'shipment_rpcclient.add_tracking_data',

--- a/conf/apps.py
+++ b/conf/apps.py
@@ -3,6 +3,9 @@ from .base import ENVIRONMENT
 # The maximum length that Transmission will wait for a transaction to be confirmed before attempting to get a new nonce
 WALLET_TIMEOUT = 900
 
+# The maximum timeout that Transmission will 'lock' a vault_id, preventing concurrent vault writes
+VAULT_TIMEOUT = 60
+
 # Celery retry intervals
 CELERY_WALLET_RETRY = 30
 CELERY_TXHASH_RETRY = 30

--- a/conf/apps.py
+++ b/conf/apps.py
@@ -4,7 +4,7 @@ from .base import ENVIRONMENT
 WALLET_TIMEOUT = 900
 
 # The maximum timeout that Transmission will 'lock' a vault_id, preventing concurrent vault writes
-VAULT_TIMEOUT = 60
+VAULT_TIMEOUT = 120
 
 # Celery retry intervals
 CELERY_WALLET_RETRY = 30


### PR DESCRIPTION
This PR fixes a few issues with our events processing logic:

- Vault redis locks are now set to expire after 2 minutes. The lock was originally introduced to prevent concurrent vault writes, but sometimes the process would exit without properly releasing the lock. This would cause any request to the events endpoint with an event that referenced that vault to block to hang indefinitely.
- Refactored/DRY'd events view
- Added other redis lock timeouts where appropriate