### PR TITLE
Update URL pattern to fix concatenated admin URLs

### DIFF
--- a/apps/urls.py
+++ b/apps/urls.py
@@ -49,7 +49,7 @@ urlpatterns = [
         TemplateView.as_view(template_name='apidoc.html'),
         name='api_schema'
     ),
-    url(r'^admin', admin.site.urls),
+    url(r'^admin/', admin.site.urls),
     url(f'{API_PREFIX[1:]}/documents/events', documents.S3Events.as_view(), name='document-events')
 ]
 urlpatterns += router.urls


### PR DESCRIPTION
- Update URL pattern to fix concatenated admin URLs e.g., /adminshipments/shipments -> /admin/shipments/shipment