### PR TITLE
Feature/asyncjobs exponential backoff

### DIFF
--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -118,8 +118,7 @@ class AsyncTask:
             self.async_job.save()
 
 
-@shared_task(bind=True, autoretry_for=(RPCError,),
-             retry_backoff=3, retry_backoff_max=60, max_retries=10)
+@shared_task(bind=True, autoretry_for=(RPCError,), retry_backoff=True)
 def async_job_fire(self):
     # Lock on Task ID to protect against tasks that are queued multiple times
     task_lock = cache.lock(self.request.id, timeout=600)

--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -118,7 +118,7 @@ class AsyncTask:
             self.async_job.save()
 
 
-@shared_task(bind=True, autoretry_for=(RPCError,), retry_backoff=True)
+@shared_task(bind=True, autoretry_for=(RPCError,), retry_backoff=True, max_retries=None)
 def async_job_fire(self):
     # Lock on Task ID to protect against tasks that are queued multiple times
     task_lock = cache.lock(self.request.id, timeout=600)

--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -118,7 +118,7 @@ class AsyncTask:
             self.async_job.save()
 
 
-@shared_task(bind=True, autoretry_for=(RPCError,), retry_backoff=True, max_retries=None) 
+@shared_task(bind=True, autoretry_for=(RPCError,), retry_backoff=True, max_retries=None)
 def async_job_fire(self):
     # Lock on Task ID to protect against tasks that are queued multiple times
     task_lock = cache.lock(self.request.id, timeout=600)

--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -118,7 +118,7 @@ class AsyncTask:
             self.async_job.save()
 
 
-@shared_task(bind=True, autoretry_for=(RPCError,), retry_backoff=True, max_retries=None)
+@shared_task(bind=True, autoretry_for=(RPCError,), retry_backoff=True, max_retries=None) 
 def async_job_fire(self):
     # Lock on Task ID to protect against tasks that are queued multiple times
     task_lock = cache.lock(self.request.id, timeout=600)

--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -118,7 +118,7 @@ class AsyncTask:
             self.async_job.save()
 
 
-@shared_task(bind=True, autoretry_for=(RPCError,), retry_backoff=True, max_retries=None)
+@shared_task(bind=True, autoretry_for=(RPCError,), retry_backoff=True, retry_backoff_max=3600, max_retries=None)
 def async_job_fire(self):
     # Lock on Task ID to protect against tasks that are queued multiple times
     task_lock = cache.lock(self.request.id, timeout=600)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1045,6 +1045,7 @@ xmltodict = "*"
 reference = "b0e6f5e98f6be8c0d23bcee9a29c09f7565f09e7"
 type = "git"
 url = "git://github.com/ShipChain/moto.git"
+
 [[package]]
 category = "main"
 description = "MessagePack (de)serializer."
@@ -1186,7 +1187,7 @@ category = "main"
 description = "C parser in Python"
 name = "pycparser"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.19"
 
 [[package]]
@@ -1336,7 +1337,7 @@ setuptools = "*"
 six = ">=1.10.0"
 
 [package.dependencies.more-itertools]
-python = ">2.7"
+python = ">=2.8"
 version = ">=4.0.0"
 
 [[package]]
@@ -1431,7 +1432,7 @@ category = "main"
 description = "YAML parser and emitter for Python"
 name = "pyyaml"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "5.1"
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1045,7 +1045,6 @@ xmltodict = "*"
 reference = "b0e6f5e98f6be8c0d23bcee9a29c09f7565f09e7"
 type = "git"
 url = "git://github.com/ShipChain/moto.git"
-
 [[package]]
 category = "main"
 description = "MessagePack (de)serializer."
@@ -1187,7 +1186,7 @@ category = "main"
 description = "C parser in Python"
 name = "pycparser"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = "*"
 version = "2.19"
 
 [[package]]
@@ -1337,7 +1336,7 @@ setuptools = "*"
 six = ">=1.10.0"
 
 [package.dependencies.more-itertools]
-python = ">=2.8"
+python = ">2.7"
 version = ">=4.0.0"
 
 [[package]]
@@ -1432,7 +1431,7 @@ category = "main"
 description = "YAML parser and emitter for Python"
 name = "pyyaml"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = "*"
 version = "5.1"
 
 [[package]]


### PR DESCRIPTION
Automatic retries were previously configured to stop after 10 attempts and a 60 sec max delay between attempts. 
Retries should now occur forever until success while backing off exponentially.

- Celery 4.2 supports automatic exponential backoff http://docs.celeryproject.org/en/master/userguide/tasks.html#automatic-retry-for-known-exceptions