### PR TITLE
Add logging for non event transfers

### DIFF
--- a/apps/eth/signals.py
+++ b/apps/eth/signals.py
@@ -2,7 +2,6 @@ import logging
 
 from django.db.models.signals import post_save
 from django.dispatch import Signal, receiver
-from influxdb_metrics.loader import log_metric
 
 # pylint:disable=invalid-name
 from apps.eth.models import Event
@@ -21,10 +20,3 @@ def event_post_save(sender, instance, **kwargs):
         for listener in instance.eth_action.ethlistener_set.all():
             event_update.send(sender=listener.listener_type.model_class(),
                               event=instance, listener=listener.listener)
-
-    if instance.event_name == 'Transfer':
-        log_metric('transmission.info', tags={'method': 'event.transfer', 'module': __name__},
-                   fields={'from_address': instance.return_values['from'],
-                           'to_address': instance.return_values['to'],
-                           'token_amount': float(instance.return_values['value'])/(10**18),
-                           'count': 1})

--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -38,11 +38,12 @@ class EventViewSet(mixins.CreateModelMixin,
             except RPCError as exc:
                 LOG.info(f"Engine RPC error processing event {event['transaction_hash']}: {exc}")
             except MultipleObjectsReturned as exc:
-                LOG.info(f"MultipleObjectsReturned during get/get_or_create for event {event['transaction_hash']}: {exc}")
+                LOG.info(f"MultipleObjectsReturned during get/get_or_create for event {event['transaction_hash']}: "
+                         f"{exc}")
             except ObjectDoesNotExist:
-                    LOG.info(f"Non-EthAction Event processed Tx: {event['transaction_hash']}")
-                    log_metric('transmission.info', tags={'method': 'events.create', 'code': 'non_ethaction_event',
-                                                          'module': __name__, 'project': project})
+                LOG.info(f"Non-EthAction Event processed Tx: {event['transaction_hash']}")
+                log_metric('transmission.info', tags={'method': 'events.create', 'code': 'non_ethaction_event',
+                                                      'module': __name__, 'project': project})
         elif project == 'SHIP' and event['event_name'] == 'Transfer':
             LOG.info(f"ShipToken Transfer processed Tx: {event['transaction_hash']}")
             log_metric('transmission.info',
@@ -52,7 +53,7 @@ class EventViewSet(mixins.CreateModelMixin,
                                'token_amount': float(event['return_values']['value']) / (10 ** 18),
                                'count': 1})
         else:
-            LOG.warn(f"Unexpected event {event} found with project: {project}")
+            LOG.warning(f"Unexpected event {event} found with project: {project}")
 
     def create(self, request, *args, **kwargs):
         log_metric('transmission.info',

--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -50,10 +50,11 @@ class EventViewSet(mixins.CreateModelMixin,
             else:
                 LOG.info(f"Non-EthAction Event processed Tx: {event['transaction_hash']}")
                 log_metric('transmission.info', tags={'method': 'events.create', 'code': 'non_ethaction_event',
-                                                      'module': __name__})
+                                                      'module': __name__, 'project': project})
 
     def create(self, request, *args, **kwargs):
-        log_metric('transmission.info', tags={'method': 'events.create', 'module': __name__})
+        log_metric('transmission.info',
+                   tags={'method': 'events.create', 'module': __name__, 'project': request.data['project']})
         LOG.debug('Events create')
 
         is_many = isinstance(request.data['events'], list)

--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -39,7 +39,7 @@ class EventViewSet(mixins.CreateModelMixin,
         except MultipleObjectsReturned as exc:
             LOG.info(f"MultipleObjectsReturned during get/get_or_create for event {event['transaction_hash']}: {exc}")
         except ObjectDoesNotExist:
-            if event['event_name'] == 'Transfer':
+            if event['event_name'] == 'Transfer' and project == 'SHIP':
                 LOG.info(f"ShipToken Transfer processed Tx: {event['transaction_hash']}")
                 log_metric('transmission.info',
                            tags={'method': 'event.transfer', 'module': __name__, 'project': project},

--- a/tests/profiles-enabled/test_events.py
+++ b/tests/profiles-enabled/test_events.py
@@ -81,27 +81,30 @@ class EventTests(APITestCase):
     def test_event_transfer(self):
         url = reverse('event-list', kwargs={'version': 'v1'})
         data = {
-            "address": "0x25Ff5dc79A7c4e34254ff0f4a19d69E491201DD3",
-            "blockNumber": 3,
-            "transactionHash": "0xc18a24a35052a5a3375ee6c2c5ddd6b0587cfa950b59468b67f63f284e2cc382",
-            "transactionIndex": 0,
-            "blockHash": "0x62469a8d113b27180c139d88a25f0348bb4939600011d33382b98e10842c85d9",
-            "logIndex": 0,
-            "removed": False,
-            "id": "log_25652065",
-            "returnValues": {
-                "from": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885",
-                "to": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885",
-                "value": 10000000000000000000000
+            'events': {
+                "address": "0x25Ff5dc79A7c4e34254ff0f4a19d69E491201DD3",
+                "blockNumber": 3,
+                "transactionHash": "0xc18a24a35052a5a3375ee6c2c5ddd6b0587cfa950b59468b67f63f284e2cc382",
+                "transactionIndex": 0,
+                "blockHash": "0x62469a8d113b27180c139d88a25f0348bb4939600011d33382b98e10842c85d9",
+                "logIndex": 0,
+                "removed": False,
+                "id": "log_25652065",
+                "returnValues": {
+                    "from": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885",
+                    "to": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885",
+                    "value": 10000000000000000000000
+                },
+                "event": "Transfer",
+                "signature": "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824",
+                "raw": {
+                    "data": "0x000000000000000000000000fcaf25bf38e7c86612a25ff18cb8e09ab07c9885",
+                    "topics": [
+                        "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824"
+                    ]
+                }
             },
-            "event": "Transfer",
-            "signature": "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824",
-            "raw": {
-                "data": "0x000000000000000000000000fcaf25bf38e7c86612a25ff18cb8e09ab07c9885",
-                "topics": [
-                    "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824"
-                ]
-            }
+            'project': 'SHIP'
         }
         response = self.client.post(url, data, format='json')
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/profiles-enabled/test_events.py
+++ b/tests/profiles-enabled/test_events.py
@@ -50,12 +50,12 @@ class EventTests(APITestCase):
 
         data = {
             'events': event,
-            'project': 'TEST'
+            'project': 'LOAD'
         }
 
         data_batched = {
             'events': [event, event],
-            'project': 'TEST'
+            'project': 'LOAD'
         }
 
         response = self.client.post(url, data, format='json')

--- a/tests/profiles-enabled/test_events.py
+++ b/tests/profiles-enabled/test_events.py
@@ -17,6 +17,7 @@ limitations under the License.
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+from mock import patch
 
 from apps.eth.models import Event
 
@@ -77,5 +78,38 @@ class EventTests(APITestCase):
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert Event.objects.count() == num_events
 
+    def test_event_transfer(self):
+        url = reverse('event-list', kwargs={'version': 'v1'})
+        data = {
+            "address": "0x25Ff5dc79A7c4e34254ff0f4a19d69E491201DD3",
+            "blockNumber": 3,
+            "transactionHash": "0xc18a24a35052a5a3375ee6c2c5ddd6b0587cfa950b59468b67f63f284e2cc382",
+            "transactionIndex": 0,
+            "blockHash": "0x62469a8d113b27180c139d88a25f0348bb4939600011d33382b98e10842c85d9",
+            "logIndex": 0,
+            "removed": False,
+            "id": "log_25652065",
+            "returnValues": {
+                "from": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885",
+                "to": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885",
+                "value": 10000000000000000000000
+            },
+            "event": "Transfer",
+            "signature": "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824",
+            "raw": {
+                "data": "0x000000000000000000000000fcaf25bf38e7c86612a25ff18cb8e09ab07c9885",
+                "topics": [
+                    "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824"
+                ]
+            }
+        }
+        response = self.client.post(url, data, format='json')
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
+        with patch('apps.eth.views.log_metric') as mocked:
+            # Set NGINX headers for engine auth
+            response = self.client.post(url, data, format='json', X_NGINX_SOURCE='internal',
+                                        X_SSL_CLIENT_VERIFY='SUCCESS', X_SSL_CLIENT_DN='/CN=engine.test-internal')
+            assert response.status_code == status.HTTP_204_NO_CONTENT
 
+            self.assertTrue(mocked.call_count == 2)

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -1635,7 +1635,7 @@ class ShipmentWithIoTAPITests(APITestCase):
                         ]
                     }
                 },
-                'project': 'TEST'
+                'project': 'LOAD'
             }
             response = self.client.post(url, data, format='json', X_NGINX_SOURCE='internal',
                                         X_SSL_CLIENT_VERIFY='SUCCESS', X_SSL_CLIENT_DN='/CN=engine.test-internal')


### PR DESCRIPTION
When a SHIP transfer occured that was not related to an event, that information would not get logged. This change fixes that and allows us to log non-event transfers.