### PR TITLE
Update admin panel title to include "Transmission"

### DIFF
--- a/apps/urls.py
+++ b/apps/urls.py
@@ -28,6 +28,8 @@ from apps.documents import views as documents
 
 API_PREFIX = r'^api/(?P<version>(v1|v2))'
 
+admin.site.site_header = 'Transmission Administration'
+
 # pylint: disable=invalid-name
 router = OptionalSlashRouter()
 


### PR DESCRIPTION
Update admin panel title to include "Transmission" instead of default "Django Administration"