### PR TITLE
Change permission denied error to be consistent with rest framework

### DIFF
--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -2,7 +2,7 @@ import logging
 from string import Template
 
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
@@ -11,7 +11,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets, permissions, status, filters, mixins
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, PermissionDenied
 from influxdb_metrics.loader import log_metric
 
 from apps.authentication import get_jwt_from_request


### PR DESCRIPTION
When there is no shipment attached to a device, we only receive a generic "permission denied" error, instead of pointing to what the error actually is.