### PR TITLE
Change how events are accepted by engine

### DIFF
--- a/apps/eth/models.py
+++ b/apps/eth/models.py
@@ -153,6 +153,7 @@ class Event(models.Model):
           "shipTokenContractAddress": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885"
         },
         "event": "SetTokenContractAddressEvent",
+        "project": "SHIP",
         "signature": "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824",
         "raw": {
           "data": "0x000000000000000000000000fcaf25bf38e7c86612a25ff18cb8e09ab07c9885",

--- a/apps/eth/models.py
+++ b/apps/eth/models.py
@@ -153,7 +153,6 @@ class Event(models.Model):
           "shipTokenContractAddress": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885"
         },
         "event": "SetTokenContractAddressEvent",
-        "project": "SHIP",
         "signature": "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824",
         "raw": {
           "data": "0x000000000000000000000000fcaf25bf38e7c86612a25ff18cb8e09ab07c9885",

--- a/tests/profiles-enabled/test_events.py
+++ b/tests/profiles-enabled/test_events.py
@@ -24,7 +24,7 @@ from apps.eth.models import Event
 class EventTests(APITestCase):
     def test_event_update(self):
         url = reverse('event-list', kwargs={'version': 'v1'})
-        data = {
+        event = {
             "address": "0x25Ff5dc79A7c4e34254ff0f4a19d69E491201DD3",
             "blockNumber": 3,
             "transactionHash": "0xc18a24a35052a5a3375ee6c2c5ddd6b0587cfa950b59468b67f63f284e2cc382",
@@ -45,8 +45,20 @@ class EventTests(APITestCase):
                 "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824"
               ]
             }
-          }
+        }
+
+        data = {
+            'events': event,
+            'project': 'TEST'
+        }
+
+        data_batched = {
+            'events': [event, event],
+            'project': 'TEST'
+        }
+
         response = self.client.post(url, data, format='json')
+        print(response.content)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
         # Set NGINX headers for engine auth
@@ -61,7 +73,7 @@ class EventTests(APITestCase):
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert Event.objects.count() == num_events
 
-        response = self.client.post(url, [data, data], format='json', X_NGINX_SOURCE='internal',
+        response = self.client.post(url, data_batched, format='json', X_NGINX_SOURCE='internal',
                                     X_SSL_CLIENT_VERIFY='SUCCESS', X_SSL_CLIENT_DN='/CN=engine.test-internal')
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert Event.objects.count() == num_events

--- a/tests/profiles-enabled/test_events.py
+++ b/tests/profiles-enabled/test_events.py
@@ -58,7 +58,6 @@ class EventTests(APITestCase):
         }
 
         response = self.client.post(url, data, format='json')
-        print(response.content)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
         # Set NGINX headers for engine auth

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -1613,26 +1613,29 @@ class ShipmentWithIoTAPITests(APITestCase):
             eth_action.ethlistener_set.create(listener=shipment_obj)
             url = reverse('event-list', kwargs={'version': 'v1'})
             data = {
-                "address": "0x25Ff5dc79A7c4e34254ff0f4a19d69E491201DD3",
-                "blockNumber": 3,
-                "transactionHash": tx_hash,
-                "transactionIndex": 0,
-                "blockHash": "0x62469a8d113b27180c139d88a25f0348bb4939600011d33382b98e10842c85d9",
-                "logIndex": 0,
-                "removed": False,
-                "id": "log_25652065",
-                "returnValues": {
-                    "0": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885",
-                    "shipTokenContractAddress": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885"
+                'events': {
+                    "address": "0x25Ff5dc79A7c4e34254ff0f4a19d69E491201DD3",
+                    "blockNumber": 3,
+                    "transactionHash": tx_hash,
+                    "transactionIndex": 0,
+                    "blockHash": "0x62469a8d113b27180c139d88a25f0348bb4939600011d33382b98e10842c85d9",
+                    "logIndex": 0,
+                    "removed": False,
+                    "id": "log_25652065",
+                    "returnValues": {
+                        "0": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885",
+                        "shipTokenContractAddress": "0xFCaf25bF38E7C86612a25ff18CB8e09aB07c9885"
+                    },
+                    "event": "ShipmentComplete",
+                    "signature": "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824",
+                    "raw": {
+                        "data": "0x000000000000000000000000fcaf25bf38e7c86612a25ff18cb8e09ab07c9885",
+                        "topics": [
+                            "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824"
+                        ]
+                    }
                 },
-                "event": "ShipmentComplete",
-                "signature": "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824",
-                "raw": {
-                    "data": "0x000000000000000000000000fcaf25bf38e7c86612a25ff18cb8e09ab07c9885",
-                    "topics": [
-                        "0xbbbf32f08c8c0621e580dcf0a8e0024525ec357db61bb4faa1a639d4f958a824"
-                    ]
-                }
+                'project': 'TEST'
             }
             response = self.client.post(url, data, format='json', X_NGINX_SOURCE='internal',
                                         X_SSL_CLIENT_VERIFY='SUCCESS', X_SSL_CLIENT_DN='/CN=engine.test-internal')


### PR DESCRIPTION
Previously when Engine sent events to Transmission, they didn't  include information about the project which supplied it. This PR is in tandem with one with Engine, and needs to be merged at the same time.