### PR TITLE
Fix Shipment Update Swagger

### DIFF
--- a/apps/schema/static/schema/swagger.yaml
+++ b/apps/schema/static/schema/swagger.yaml
@@ -1700,7 +1700,7 @@ components:
               type: string
               example: '2018-08-22T17:44:39.874352'
 
-        deliveryAppt:
+        deliveryApptAct:
           properties:
             delivery_appt_act:
               title: delivery_appt_act
@@ -1708,7 +1708,7 @@ components:
               type: string
               example: '2018-08-22T17:44:39.874352'
 
-        arrivalPortEst:
+        portArrivalEst:
           properties:
             port_arrival_est:
               title: port_arrival_est
@@ -1716,7 +1716,7 @@ components:
               type: string
               example: '2018-08-22T17:44:39.874352'
 
-        arrivalPortAct:
+        portArrivalAct:
           properties:
             port_arrival_act:
               title: port_arrival_act
@@ -1796,7 +1796,7 @@ components:
               type: string
               example: 'BULK'
 
-        arrivalLocode:
+        portArrivalLocode:
           properties:
             port_arrival_locode:
               title: port_arrival_locode
@@ -2801,9 +2801,9 @@ components:
         - $ref: '#/components/schemas/dataTypes/shipment/loadingAct'
         - $ref: '#/components/schemas/dataTypes/shipment/departureEst'
         - $ref: '#/components/schemas/dataTypes/shipment/departureAct'
-        - $ref: '#/components/schemas/dataTypes/shipment/deliveryAppt'
-        - $ref: '#/components/schemas/dataTypes/shipment/arrivalPortEst'
-        - $ref: '#/components/schemas/dataTypes/shipment/arrivalPortAct'
+        - $ref: '#/components/schemas/dataTypes/shipment/deliveryApptAct'
+        - $ref: '#/components/schemas/dataTypes/shipment/portArrivalEst'
+        - $ref: '#/components/schemas/dataTypes/shipment/portArrivalAct'
         - $ref: '#/components/schemas/dataTypes/shipment/deliveryEst'
         - $ref: '#/components/schemas/dataTypes/shipment/deliveryAct'
         - $ref: '#/components/schemas/dataTypes/shipment/deliveryAttempt'
@@ -2813,7 +2813,7 @@ components:
         - $ref: '#/components/schemas/dataTypes/shipment/customsHoldDateAct'
         - $ref: '#/components/schemas/dataTypes/shipment/customsReleaseDateAct'
         - $ref: '#/components/schemas/dataTypes/shipment/containerType'
-        - $ref: '#/components/schemas/dataTypes/shipment/arrivalLocode'
+        - $ref: '#/components/schemas/dataTypes/shipment/portArrivalLocode'
         - $ref: '#/components/schemas/dataTypes/shipment/finalPortLocode'
         - $ref: '#/components/schemas/dataTypes/shipment/importLocode'
         - $ref: '#/components/schemas/dataTypes/shipment/ladingLocode'
@@ -2941,9 +2941,9 @@ components:
         - $ref: '#/components/schemas/dataTypes/shipment/loadingAct'
         - $ref: '#/components/schemas/dataTypes/shipment/departureEst'
         - $ref: '#/components/schemas/dataTypes/shipment/departureAct'
-        - $ref: '#/components/schemas/dataTypes/shipment/deliveryAppt'
-        - $ref: '#/components/schemas/dataTypes/shipment/arrivalPortEst'
-        - $ref: '#/components/schemas/dataTypes/shipment/arrivalPortAct'
+        - $ref: '#/components/schemas/dataTypes/shipment/deliveryApptAct'
+        - $ref: '#/components/schemas/dataTypes/shipment/portArrivalEst'
+        - $ref: '#/components/schemas/dataTypes/shipment/portArrivalAct'
         - $ref: '#/components/schemas/dataTypes/shipment/deliveryEst'
         - $ref: '#/components/schemas/dataTypes/shipment/deliveryAct'
         - $ref: '#/components/schemas/dataTypes/shipment/deliveryAttempt'
@@ -2953,7 +2953,7 @@ components:
         - $ref: '#/components/schemas/dataTypes/shipment/customsHoldDateAct'
         - $ref: '#/components/schemas/dataTypes/shipment/customsReleaseDateAct'
         - $ref: '#/components/schemas/dataTypes/shipment/containerType'
-        - $ref: '#/components/schemas/dataTypes/shipment/arrivalLocode'
+        - $ref: '#/components/schemas/dataTypes/shipment/portArrivalLocode'
         - $ref: '#/components/schemas/dataTypes/shipment/finalPortLocode'
         - $ref: '#/components/schemas/dataTypes/shipment/importLocode'
         - $ref: '#/components/schemas/dataTypes/shipment/ladingLocode'
@@ -3584,9 +3584,9 @@ components:
         - $ref: '#/components/schemas/dataTypes/shipment/loadingAct'
         - $ref: '#/components/schemas/dataTypes/shipment/departureEst'
         - $ref: '#/components/schemas/dataTypes/shipment/departureAct'
-        - $ref: '#/components/schemas/dataTypes/shipment/deliveryAppt'
-        - $ref: '#/components/schemas/dataTypes/shipment/arrivalPortEst'
-        - $ref: '#/components/schemas/dataTypes/shipment/arrivalPortAct'
+        - $ref: '#/components/schemas/dataTypes/shipment/deliveryApptAct'
+        - $ref: '#/components/schemas/dataTypes/shipment/portArrivalEst'
+        - $ref: '#/components/schemas/dataTypes/shipment/portArrivalAct'
         - $ref: '#/components/schemas/dataTypes/shipment/deliveryEst'
         - $ref: '#/components/schemas/dataTypes/shipment/deliveryAct'
         - $ref: '#/components/schemas/dataTypes/shipment/deliveryAttempt'
@@ -3596,7 +3596,7 @@ components:
         - $ref: '#/components/schemas/dataTypes/shipment/customsHoldDateAct'
         - $ref: '#/components/schemas/dataTypes/shipment/customsReleaseDateAct'
         - $ref: '#/components/schemas/dataTypes/shipment/containerType'
-        - $ref: '#/components/schemas/dataTypes/shipment/arrivalLocode'
+        - $ref: '#/components/schemas/dataTypes/shipment/portArrivalLocode'
         - $ref: '#/components/schemas/dataTypes/shipment/finalPortLocode'
         - $ref: '#/components/schemas/dataTypes/shipment/importLocode'
         - $ref: '#/components/schemas/dataTypes/shipment/ladingLocode'
@@ -3646,9 +3646,9 @@ components:
           - $ref: '#/components/schemas/dataTypes/shipment/loadingAct'
           - $ref: '#/components/schemas/dataTypes/shipment/departureEst'
           - $ref: '#/components/schemas/dataTypes/shipment/departureAct'
-          - $ref: '#/components/schemas/dataTypes/shipment/deliveryAppt'
-          - $ref: '#/components/schemas/dataTypes/shipment/arrivalPortEst'
-          - $ref: '#/components/schemas/dataTypes/shipment/arrivalPortAct'
+          - $ref: '#/components/schemas/dataTypes/shipment/deliveryApptAct'
+          - $ref: '#/components/schemas/dataTypes/shipment/portArrivalEst'
+          - $ref: '#/components/schemas/dataTypes/shipment/portArrivalAct'
           - $ref: '#/components/schemas/dataTypes/shipment/deliveryEst'
           - $ref: '#/components/schemas/dataTypes/shipment/deliveryAct'
           - $ref: '#/components/schemas/dataTypes/shipment/deliveryAttempt'
@@ -3658,7 +3658,7 @@ components:
           - $ref: '#/components/schemas/dataTypes/shipment/customsHoldDateAct'
           - $ref: '#/components/schemas/dataTypes/shipment/customsReleaseDateAct'
           - $ref: '#/components/schemas/dataTypes/shipment/containerType'
-          - $ref: '#/components/schemas/dataTypes/shipment/arrivalLocode'
+          - $ref: '#/components/schemas/dataTypes/shipment/portArrivalLocode'
           - $ref: '#/components/schemas/dataTypes/shipment/finalPortLocode'
           - $ref: '#/components/schemas/dataTypes/shipment/importLocode'
           - $ref: '#/components/schemas/dataTypes/shipment/ladingLocode'

--- a/apps/schema/static/schema/swagger.yaml
+++ b/apps/schema/static/schema/swagger.yaml
@@ -1702,24 +1702,24 @@ components:
 
         deliveryAppt:
           properties:
-            delivery_appt:
-              title: delivery_appt
+            delivery_appt_act:
+              title: delivery_appt_act
               description: Delivery appointment timestamp
               type: string
               example: '2018-08-22T17:44:39.874352'
 
         arrivalPortEst:
           properties:
-            arrival_port_est:
-              title: arrival_port_est
+            port_arrival_est:
+              title: port_arrival_est
               description: Estimated timestamp of arrival at destination port
               type: string
               example: '2018-08-22T17:44:39.874352'
 
         arrivalPortAct:
           properties:
-            arrival_port_act:
-              title: arrival_port_act
+            port_arrival_act:
+              title: port_arrival_act
               description: Timestamp of actual arrival at destination port
               type: string
               example: '2018-08-22T17:44:39.874352'
@@ -1798,8 +1798,8 @@ components:
 
         arrivalLocode:
           properties:
-            arrival_locode:
-              title: arrival_locode
+            port_arrival_locode:
+              title: port_arrival_locode
               description: UN/LOCODE for destination port
               type: string
               example: 'USCHI'
@@ -3613,15 +3613,9 @@ components:
         - $ref: '#/components/schemas/dataTypes/shipment/isHazmat'
 
       patchAttributes:
-#        required:
-#          - shipper_wallet_id
-#          - carrier_wallet_id
-#          - storage_credentials_id
+
         allOf:
-#          - $ref: '#/components/schemas/dataTypes/shipment/storageCredentialsId'
-#          - $ref: '#/components/schemas/dataTypes/shipment/vaultId'
-#          - $ref: '#/components/schemas/dataTypes/shipment/shipperWalletId'
-#          - $ref: '#/components/schemas/dataTypes/shipment/carrierWalletId'
+          - $ref: '#/components/schemas/dataTypes/shipment/deviceId'
           - $ref: '#/components/schemas/dataTypes/shipment/carriersScac'
           - $ref: '#/components/schemas/dataTypes/shipment/forwardersScac'
           - $ref: '#/components/schemas/dataTypes/shipment/nvoccScac'
@@ -3672,6 +3666,11 @@ components:
           - $ref: '#/components/schemas/dataTypes/shipment/usRouted'
           - $ref: '#/components/schemas/dataTypes/shipment/importCustomsMode'
           - $ref: '#/components/schemas/dataTypes/shipment/usExportPort'
+          - $ref: '#/components/schemas/dataTypes/shipment/trailerNumber'
+          - $ref: '#/components/schemas/dataTypes/shipment/sealNumber'
+          - $ref: '#/components/schemas/dataTypes/shipment/isMasterBOL'
+          - $ref: '#/components/schemas/dataTypes/shipment/isHazmat'
+          - $ref: '#/components/schemas/dataTypes/shipment/nmfcClass'
           - $ref: '#/components/schemas/dataTypes/shipment/customerFields'
 
       createRequest:


### PR DESCRIPTION
It is important to have swagger that accurately depicts the requirements for our Rest API Calls. This change fixes some of the inconsistencies with the documentation and the usage of the shipment update call.