### PR TITLE
Ignore duplicate job messages

### DIFF
--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -10,7 +10,7 @@ from influxdb_metrics.loader import log_metric
 from apps.authentication import EngineRequest
 from apps.permissions import get_owner_id
 from apps.shipments.permissions import IsListenerOwner
-from .models import AsyncJob
+from .models import AsyncJob, Message
 from .serializers import AsyncJobSerializer, MessageSerializer
 
 LOG = logging.getLogger('transmission')
@@ -44,6 +44,6 @@ class JobsViewSet(mixins.ListModelMixin,
         serializer = MessageSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        serializer.save(async_job_id=pk)
+        Message.objects.get_or_create(**serializer.data, async_job_id=pk)
 
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Currently if an AsyncJob Message is POST'd 2+ times to the job message endpoint, it will create a Message object for each POST, even if the payload is identical. This endpoint should be idempotent; identical messages should be ignored if they are re-delivered to Transmission.

Currently this is possible in a couple edge-casey scenarios - if there are two instances of Engine running, for example. Although I have seen evidence of duplicate messages existing in some of our environments, I don't think this is causing any issues at the moment, this is more of a preemptive bugfix :smile: 