### PR TITLE
Add migration health check endpoint

### DIFF
--- a/apps/management/views.py
+++ b/apps/management/views.py
@@ -1,0 +1,32 @@
+#  Copyright 2019 ShipChain, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.executor import MigrationExecutor
+from django.http.response import HttpResponse
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes, authentication_classes
+
+
+@api_view(['GET'])
+@authentication_classes(())
+@permission_classes((permissions.AllowAny,))
+def health_check(request):
+    """
+    This endpoint (/health) returns 200 if no migrations are pending, else 503
+    https://engineering.instawork.com/elegant-database-migrations-on-ecs-74f3487da99f
+    """
+    executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
+    plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+    return HttpResponse(status=503 if plan else 200)

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -19,12 +19,12 @@ from django.views.generic import TemplateView
 from rest_framework.urlpatterns import format_suffix_patterns
 from rest_framework_nested import routers as drf_nested_routers
 
-from apps.routing import OptionalSlashRouter
-from apps.jobs import views as jobs
-from apps.shipments import views as shipments
-from apps.eth import views as eth
 from apps.documents import views as documents
-
+from apps.eth import views as eth
+from apps.jobs import views as jobs
+from apps.management import views as management
+from apps.routing import OptionalSlashRouter
+from apps.shipments import views as shipments
 
 API_PREFIX = r'^api/(?P<version>(v1|v2))'
 
@@ -47,6 +47,7 @@ nested_router.register(r'permission_links', shipments.PermissionLinkViewSet, bas
 nested_router.register(r'history', shipments.ShipmentHistoryListView, base_name='shipment-history')
 
 urlpatterns = [
+    url('health', management.health_check, name='health'),
     url(
         r'(^(api/v1/schema)|^$)',
         TemplateView.as_view(template_name='apidoc.html'),

--- a/compose/django/entrypoint.sh
+++ b/compose/django/entrypoint.sh
@@ -18,7 +18,6 @@ then
     echo "Deactivating AWS CLI virtualenv"
     deactivate
 
-    python manage.py migrate
 else
     echo "Waiting for dependencies to come up in the stack"
     /wait-for-it.sh ${REDIS_NAME:-redis_db}:6379


### PR DESCRIPTION
For deployed environments, we are moving away from having our migrations run in our entrypoint script, instead having them run in a one-off ECS task that is triggered by our CircleCI deployment lambda. This change is to address the possibility of more than one containers running the same migration script at the same time (this will definitely happen with any long-running data migration).

The change in this PR is to add a `/health` endpoint that will either return a 503 if there are pending migrations, or a 200 if the DB is otherwise healthy. This serves a few purposes

- It is a leaner health check than the current one, which serves our entire swagger docs every time a request is made
- We can leverage the properties of ECS deployments and ELB health checks to ensure a minimal-downtime migration takes place. Newly deployed ECS tasks that have unapplied migrations will not report 'healthy' until the one-off ECS migration task has completed, at which point the ELB will start replacing the old tasks with the new (now healthy) tasks.

Stole this from https://engineering.instawork.com/elegant-database-migrations-on-ecs-74f3487da99f