### PR TITLE
Local development file permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,13 @@ FROM base AS build
 RUN apk add --no-cache build-base git libffi-dev linux-headers jpeg-dev libressl2.7-libssl freetype-dev postgresql-dev
 
 
+## Image with additional dependencies for local docker usage ##
+## ========================================================= ##
+FROM build as local
+RUN chmod -R 777 /root/  ## Grant all local users access to poetry
+RUN apk add --no-cache su-exec
+
+
 ## Image with dev-dependencies ##
 ## =========================== ##
 FROM build AS test

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,13 @@ ENTRYPOINT ["/entrypoint.sh"]
 FROM base AS build
 
 # Essential packages for building python packages
-RUN apk add --no-cache build-base git libffi-dev linux-headers jpeg-dev libressl2.7-libssl freetype-dev postgresql-dev
+RUN apk add --no-cache build-base git libffi-dev linux-headers jpeg-dev libressl2.7-libssl freetype-dev postgresql-dev su-exec
 
 
 ## Image with additional dependencies for local docker usage ##
 ## ========================================================= ##
 FROM build as local
 RUN chmod -R 777 /root/  ## Grant all local users access to poetry
-RUN apk add --no-cache su-exec
 
 
 ## Image with dev-dependencies ##

--- a/bin/ddo
+++ b/bin/ddo
@@ -1,2 +1,2 @@
 #!/bin/bash
-bin/dc run --rm --entrypoint /entrypoint.sh -e IS_DDO=1 django_shell $*
+bin/dc run --rm -e LOCAL_USER_ID=`id -u $USER` -e LOCAL_GROUP_ID=`id -g $USER` --entrypoint /entrypoint.sh -e IS_DDO=1 django_shell $*

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -72,7 +72,7 @@ services:
   runserver:
     build:
       context: ../
-      target: build
+      target: local
     image: transmission-django-dev
     command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
     ports:

--- a/compose/django/entrypoint.sh
+++ b/compose/django/entrypoint.sh
@@ -18,6 +18,7 @@ then
     echo "Deactivating AWS CLI virtualenv"
     deactivate
 
+    exec "$@"
 else
     echo "Waiting for dependencies to come up in the stack"
     /wait-for-it.sh ${REDIS_NAME:-redis_db}:6379
@@ -28,6 +29,9 @@ else
     then
         python manage.py migrate
     fi
+    USER_ID=${LOCAL_USER_ID:0}
+    GROUP_ID=${LOCAL_GROUP_ID:0}
+    echo "Starting with GUID:UID : $GROUP_ID:$USER_ID"
+    addgroup -g $GROUP_ID -S username && adduser -u $USER_ID -S username -G username
+    exec su-exec $USER_ID:$GROUP_ID "$@"
 fi
-
-exec "$@"


### PR DESCRIPTION
Currently, the user in our local docker containers is always `root`, which means `dmg makemigrations` and any other command that goes through `ddo` will create files with the file owner being `root`. Which means that after the files are copied back via the volume mount, locally your user won't have access to modify the files without `sudo`.

This branch applies a fix, copying the local user/group ID into the container and using su-exec to execute the desired command as the appropriate user. Then any files created during the exec will be owned by the host user.

*NOTE*: You will most likely need to run this command to fix all your local file permissions prior to using this patch.
```sudo chown -R `id -u $USER`:`id -g $USER` .```