### PR TITLE
Fix test settings import when running docker-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           name: Run unit tests and coverage report
           command: |
             bin/dc exec -T runserver pytest --junitxml=test-results/pytest/results-pe.xml --cov=apps --cov-config=.coveragerc --cov-report= tests/profiles-enabled
-            bin/dc exec -T runserver pytest --junitxml=test-results/pytest/results-pd.xml --cov=apps --cov-config=.coveragerc --cov-report=html:test-results/coverage.html --cov-append --ds=conf/test_settings_profiles_disabled tests/profiles-disabled
+            bin/dc exec -T runserver pytest --junitxml=test-results/pytest/results-pd.xml --cov=apps --cov-config=.coveragerc --cov-report=html:test-results/coverage.html --cov-append --ds=conf.test_settings_profiles_disabled tests/profiles-disabled
       - run:
           name: Copy artifacts from Docker
           command: |

--- a/bin/docker_tests
+++ b/bin/docker_tests
@@ -21,6 +21,6 @@ bin/dc exec -T runserver bandit -r apps
 
 bin/dc exec -T runserver pytest -p no:cacheprovider --cov=apps --cov-config=.coveragerc --cov-report= tests/profiles-enabled
 
-bin/dc exec -T runserver pytest -p no:cacheprovider --cov=apps --cov-config=.coveragerc --cov-append --ds=conf/test_settings_profiles_disabled tests/profiles-disabled
+bin/dc exec -T runserver pytest -p no:cacheprovider --cov=apps --cov-config=.coveragerc --cov-append --ds=conf.test_settings_profiles_disabled tests/profiles-disabled
 
 bin/dc down

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = conf/test_settings
+DJANGO_SETTINGS_MODULE = conf.test_settings
 # -- recommended but optional:
 python_files = tests.py test_*.py *_tests.py
 addopts = -p no:warnings


### PR DESCRIPTION
I have been experiencing a test settings import error when running docker tests locally. This `PR` is to address this issue by using `con.test_settings` instead of `con/test_settings`.