### PR TITLE
Fix virtualenv permissions for local development

### DIFF
--- a/compose/django/entrypoint.sh
+++ b/compose/django/entrypoint.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 
+USER_ID=${LOCAL_USER_ID:0}
+GROUP_ID=${LOCAL_GROUP_ID:0}
+echo "Starting with GUID:UID : $GROUP_ID:$USER_ID"
+if [[ USER_ID -ne 0 ]];
+then
+    addgroup -g $GROUP_ID -S username && adduser -u $USER_ID -S username -G username
+fi
+
 if [[ ! -f $VIRTUAL_ENV/bin/python ]];
 then
     echo "Creating virtualenv"
-    virtualenv $VIRTUAL_ENV
+    su-exec $USER_ID:$GROUP_ID virtualenv $VIRTUAL_ENV
 fi
 
 if [[ "$ENV" = "PROD" ]] || [[ "$ENV" = "DEMO" ]] || [[ "$ENV" = "STAGE" ]] || [[ "$ENV" = "DEV" ]];
@@ -29,9 +37,5 @@ else
     then
         python manage.py migrate
     fi
-    USER_ID=${LOCAL_USER_ID:0}
-    GROUP_ID=${LOCAL_GROUP_ID:0}
-    echo "Starting with GUID:UID : $GROUP_ID:$USER_ID"
-    addgroup -g $GROUP_ID -S username && adduser -u $USER_ID -S username -G username
     exec su-exec $USER_ID:$GROUP_ID "$@"
 fi


### PR DESCRIPTION
If the poetry virtualenv (`.virtualenv`) does not exist yet locally, it is created by the entrypoint script using the root user. This results in permissions issues during subsequent updates. This change to the entrypoint script ensures that the virtualenv is created with the host's user/group, so that they have access to perform future updates to the virtualenv.