### PR TITLE
Change project name check to be accurate with Engine

### DIFF
--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -48,7 +48,7 @@ class EventViewSet(mixins.CreateModelMixin,
                 LOG.info(f"Non-EthAction Event processed Tx: {event['transaction_hash']}")
                 log_metric('transmission.info', tags={'method': 'events.create', 'code': 'non_ethaction_event',
                                                       'module': __name__, 'project': project})
-        elif project == 'SHIP' and event['event_name'] == 'Transfer':
+        elif project == 'ShipToken' and event['event_name'] == 'Transfer':
             LOG.info(f"ShipToken Transfer processed Tx: {event['transaction_hash']}")
             log_metric('transmission.info',
                        tags={'method': 'event.transfer', 'module': __name__, 'project': project},

--- a/tests/profiles-enabled/test_events.py
+++ b/tests/profiles-enabled/test_events.py
@@ -104,7 +104,7 @@ class EventTests(APITestCase):
                     ]
                 }
             },
-            'project': 'SHIP'
+            'project': 'ShipToken'
         }
         response = self.client.post(url, data, format='json')
         assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
Change project name check from SHIP to ShipToken to be more accurate to processed event.