### PR TITLE
Fix Profiles Disabled Requests

### DIFF
--- a/apps/authentication.py
+++ b/apps/authentication.py
@@ -36,6 +36,8 @@ def get_jwt_from_request(request):
     """
     This is for retrieving the decoded JWT from the a request via the simplejwt authenticator.
     """
+    if not settings.PROFILES_ENABLED:
+        return None
     return (request.authenticators[-1].get_raw_token(request.authenticators[-1].get_header(request)).decode()
             if request.authenticators else None)
 

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -53,8 +53,6 @@ class DocumentViewSet(mixins.CreateModelMixin,
         queryset = self.queryset
         shipment_id = self.kwargs['shipment_pk']
         queryset = queryset.filter(shipment__id=shipment_id)
-        # if settings.PROFILES_ENABLED:
-        #     queryset.filter(owner_id=get_owner_id(self.request))
         return queryset
 
     def perform_create(self, serializer):

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -50,10 +50,7 @@ class DocumentViewSet(mixins.CreateModelMixin,
     filter_class = DocumentFilterSet
 
     def get_queryset(self):
-        queryset = self.queryset
-        shipment_id = self.kwargs['shipment_pk']
-        queryset = queryset.filter(shipment__id=shipment_id)
-        return queryset
+        return self.queryset.filter(shipment__id=self.kwargs['shipment_pk'])
 
     def perform_create(self, serializer):
         if settings.PROFILES_ENABLED:

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -51,10 +51,11 @@ class DocumentViewSet(mixins.CreateModelMixin,
 
     def get_queryset(self):
         queryset = self.queryset
-        if settings.PROFILES_ENABLED:
-            shipment_id = self.kwargs['shipment_pk']
-            return queryset.filter(shipment__id=shipment_id)
-        return queryset.filter(owner_id=get_owner_id(self.request))
+        shipment_id = self.kwargs['shipment_pk']
+        queryset = queryset.filter(shipment__id=shipment_id)
+        # if settings.PROFILES_ENABLED:
+        #     queryset.filter(owner_id=get_owner_id(self.request))
+        return queryset
 
     def perform_create(self, serializer):
         if settings.PROFILES_ENABLED:

--- a/apps/imports/views.py
+++ b/apps/imports/views.py
@@ -45,7 +45,9 @@ class ShipmentImportsViewSet(mixins.CreateModelMixin,
     filter_class = ShipmentImportFilterSet
 
     def get_queryset(self):
-        return self.queryset.filter(owner_access_filter(self.request))
+        if settings.PROFILES_ENABLED:
+            return self.queryset.filter(owner_access_filter(self.request))
+        return self.queryset
 
     def perform_create(self, serializer):
         if settings.PROFILES_ENABLED:

--- a/apps/permissions.py
+++ b/apps/permissions.py
@@ -24,7 +24,7 @@ from apps.authentication import get_jwt_from_request
 from apps.shipments.models import Shipment, PermissionLink
 
 
-PROFILES_URL = f'{settings.PROFILES_URL}/api/v1/wallet'
+PROFILES_WALLET_URL = f'{settings.PROFILES_URL}/api/v1/wallet'
 
 
 def get_user(request):
@@ -52,7 +52,7 @@ def is_carrier(request, shipment):
     """
     Custom permission for carrier shipment access
     """
-    response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.carrier_wallet_id}/?is_active',
+    response = settings.REQUESTS_SESSION.get(f'{PROFILES_WALLET_URL}/{shipment.carrier_wallet_id}/?is_active',
                                              headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
 
     return response.status_code == status.HTTP_200_OK and request.method in ('GET', 'PATCH')
@@ -63,7 +63,7 @@ def is_moderator(request, shipment):
     Custom permission for moderator shipment access
     """
     if shipment.moderator_wallet_id:
-        response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.moderator_wallet_id}/?is_active',
+        response = settings.REQUESTS_SESSION.get(f'{PROFILES_WALLET_URL}/{shipment.moderator_wallet_id}/?is_active',
                                                  headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
 
         return response.status_code == status.HTTP_200_OK and request.method in ('GET', 'PATCH')
@@ -75,7 +75,7 @@ def is_shipper(request, shipment):
     """
     Custom permission for shipper shipment access
     """
-    response = settings.REQUESTS_SESSION.get(f'{PROFILES_URL}/{shipment.shipper_wallet_id}/?is_active',
+    response = settings.REQUESTS_SESSION.get(f'{PROFILES_WALLET_URL}/{shipment.shipper_wallet_id}/?is_active',
                                              headers={'Authorization': f'JWT {get_jwt_from_request(request)}'})
 
     return response.status_code == status.HTTP_200_OK and request.method in ('GET', 'PATCH')

--- a/apps/schema/static/schema/components/transactions/parameters.yaml
+++ b/apps/schema/static/schema/components/transactions/parameters.yaml
@@ -14,6 +14,14 @@ wallet_id:
   schema:
     $ref: '#/dataTypes/uuid'
 
+wallet_address:
+  required: true
+  name: wallet_address
+  in: query
+  description: Wallet Address to filter transactions by
+  schema:
+    $ref: '#/ethereum/address'
+
 include_async_job_action:
   required: false
   name: include

--- a/apps/schema/static/schema/components/transactions/transactions.yaml
+++ b/apps/schema/static/schema/components/transactions/transactions.yaml
@@ -6,7 +6,7 @@ get:
     - $ref: '../core/parameters.yaml#/page'
     - $ref: '../core/parameters.yaml#/page_size'
     - $ref: '../core/parameters.yaml#/ordering'
-    - $ref: 'parameters.yaml#/wallet_id'
+    - $ref: 'parameters.yaml#/wallet_address'
   tags:
   - Transactions
   responses:

--- a/apps/shipments/views.py
+++ b/apps/shipments/views.py
@@ -194,10 +194,7 @@ class PermissionLinkViewSet(mixins.CreateModelMixin,
     resource_name = 'PermissionLink'
 
     def get_queryset(self):
-        queryset = self.queryset
-        if settings.PROFILES_ENABLED:
-            queryset = queryset.filter(shipment_id=self.kwargs['shipment_pk'])
-        return queryset
+        return self.queryset.filter(shipment_id=self.kwargs['shipment_pk'])
 
     def create(self, request, *args, **kwargs):
         """

--- a/tests/profiles-disabled/test_shipment_imports.py
+++ b/tests/profiles-disabled/test_shipment_imports.py
@@ -52,3 +52,8 @@ class ShipmentImportsViewSetAPITests(APITestCase):
         self.assertEqual(data['attributes']['upload_status'], 'PENDING')
         self.assertTrue(isinstance(data['meta']['presigned_s3']['fields'], dict))
 
+        # Ensure the shipment import comes
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()['data']
+        self.assertEqual(len(data), 1)


### PR DESCRIPTION
There were some calls that were not behaving as expected when making calls when ```PROFILES_ENABLED = False```. This push fixes these issues, often by modifying the get_queryset.