### PR TITLE
Bug fixes shipment history

### DIFF
--- a/apps/schema/static/schema/components/shipmentHistory/parameters.yaml
+++ b/apps/schema/static/schema/components/shipmentHistory/parameters.yaml
@@ -3,16 +3,19 @@ historyDateLessThan:
   in: query
   name: history_date__lte
   description: Query for changes with Date time less than the provided value
+  allowReserved: true
   schema:
     type: string
     format: date-time
-    example: '2019-06-05T14:54:56-04:00'
+    example: "2019-06-05T14:54:56-04:00"
 
 historyDateGreaterThan:
   required: false
   in: query
   name: history_date__gte
   description: Query for changes with Date time grester than the provided value
+  allowReserved: true
   schema:
     type: string
     format: date-time
+    example: "2019-06-05T14:54:56-04:00"

--- a/apps/schema/static/schema/components/shipmentHistory/shipmentHistory.yaml
+++ b/apps/schema/static/schema/components/shipmentHistory/shipmentHistory.yaml
@@ -16,7 +16,7 @@ get:
       content:
         application/vnd.api+json:
           schema:
-            $ref: '../shipments/schema.yaml#/listResponse'
+            $ref: 'schema.yaml#/listResponse'
     '401':
       description: "Unauthorized"
       content:

--- a/apps/shipments/serializers.py
+++ b/apps/shipments/serializers.py
@@ -409,7 +409,7 @@ class TrackingDataToDbSerializer(rest_serializers.ModelSerializer):
 
 class ChangesDiffSerializer:
     relation_fields = settings.RELATED_FIELDS_WITH_HISTORY_MAP.keys()
-    excluded_fields = ('history_user', 'version', 'customer_fields', )
+    excluded_fields = ('history_user', 'version', 'customer_fields', 'geometry', )
 
     # Enum field serializers
     state = UpperEnumField(TransitState, lenient=True, ints_as_names=True, read_only=True)
@@ -431,7 +431,7 @@ class ChangesDiffSerializer:
         relation_changes = self.relation_changes(new)
         json_field_changes = self.json_field_changes(new, old)
 
-        for json_field, json_changes in json_field_changes.items():
+        for _, json_changes in json_field_changes.items():
             flat_changes.extend(json_changes)
 
         return {

--- a/apps/simple_history.py
+++ b/apps/simple_history.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 import copy
 import logging
+from functools import lru_cache
 
 from django.conf import settings
 from django.db import models
@@ -75,14 +76,14 @@ class HistoricalChangesMixin:
                     changes.append(change)
                     changed_fields.append(field)
             elif from_json_field:
-                old_value = None
-                change = ModelChange(field, old_value, new_value)
+                change = ModelChange(field, None, new_value)
                 changes.append(change)
                 changed_fields.append(field)
 
         return ModelDelta(changes, changed_fields, old_historical_obj, self)
 
     @property
+    @lru_cache()
     def json_fields(self):
         list_json_fields = []
         for field in self.instance._meta.get_fields():

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -6,11 +6,11 @@ from unittest import mock
 
 import boto3
 import httpretty
+import geocoder
 from datetime import datetime, timezone, timedelta
 from dateutil import parser
 from django.conf import settings as test_settings
 from django.core import mail
-from django.contrib.gis.geos import Point
 from freezegun import freeze_time
 from jose import jws
 from moto import mock_iot
@@ -26,7 +26,7 @@ from apps.shipments.rpc import Load110RPCClient
 from apps.utils import random_id
 from tests.utils import get_jwt
 from tests.utils import replace_variables_in_string, create_form_content, mocked_rpc_response, random_timestamp, \
-    random_location
+    random_location, GeoCoderResponse
 
 boto3.setup_default_session()  # https://github.com/spulec/moto/issues/1926
 
@@ -634,7 +634,8 @@ class ShipmentAPITests(APITestCase):
         return [item[field_name] for item in changes_list]
 
     @mock_iot
-    def test_shipment_history(self):
+    @mock.patch('apps.shipments.models.mapbox_access_token', return_value='TEST_ACCESS_KEYS')
+    def test_shipment_history(self, mock_mapbox):
         from apps.rpc_client import requests
         from tests.utils import mocked_rpc_response
 
@@ -708,6 +709,10 @@ class ShipmentAPITests(APITestCase):
             # On shipment creation, the most recent change is from a background task. Should have a null author.
             self.assertIsNone(history_data[0]['author'])
 
+            # version field shouldn't be in historical changes
+            changed_fields = self.get_changed_fields(history_data[1]['fields'], 'field')
+            self.assertTrue('version' not in changed_fields)
+
             url_patch = reverse('shipment-detail', kwargs={'version': 'v1', 'pk': shipment_id})
 
             # Existing shipment updated with new fields values should have history diff
@@ -721,12 +726,12 @@ class ShipmentAPITests(APITestCase):
             self.assertTrue(len(fields) > 0)
             changed_fields = self.get_changed_fields(fields, 'field')
             self.assertTrue('package_qty' in changed_fields)
-            self.assertFalse('pickup_act' in changed_fields)  # pickup_act should not be editable
+            self.assertTrue('pickup_act' not in changed_fields)  # pickup_act should not be editable
 
             # ----------------------- Shipment update with a location field --------------------------#
             # Equivalently valid for any location field
-            with mock.patch('apps.shipments.models.Location.get_lat_long_from_address') as mock_geocoder:
-                mock_geocoder.return_value = Point((53.1, -35.87))
+            with mock.patch.object(geocoder, 'mapbox') as mock_geocoder:
+                mock_geocoder.return_value = GeoCoderResponse(status=True, point=(53.1, -35.87))
 
                 shipment_creation_with_location, content_type = create_form_content({
                     'vault_id': VAULT_ID,
@@ -747,7 +752,10 @@ class ShipmentAPITests(APITestCase):
                 # Creating a shipment with a location should be reflected in the initial diff history
                 response = self.client.post(url, shipment_creation_with_location, content_type=content_type)
                 self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
-                shipment2_id = response.json()['data']['id']
+                shipment2 = response.json()
+                # The created shipment has the geometry field populated
+                self.assertTrue(isinstance(shipment2['included'][1]['attributes']['geometry'], dict))
+                shipment2_id = shipment2['data']['id']
 
                 shipment2_history_url = reverse('shipment-history-list', kwargs={'version': 'v1', 'shipment_pk': shipment2_id})
 
@@ -757,6 +765,9 @@ class ShipmentAPITests(APITestCase):
                 changed_fields = self.get_changed_fields(history_data['fields'], 'field')
                 self.assertTrue('ship_from_location' in changed_fields)
                 self.assertTrue('ship_from_location' in history_data['relationships'].keys())
+                # The shipment location geometry field should not be part of the historical changes
+                location_fields = self.get_changed_fields(history_data['relationships']['ship_from_location'], 'field')
+                self.assertTrue('geometry' not in location_fields)
 
                 # Updating a shipment with a location object, should be reflected in both fields
                 # and relationships fields in response data
@@ -816,6 +827,50 @@ class ShipmentAPITests(APITestCase):
                 self.assertIn('device', changed_fields)
                 self.assertIn('updated_by', changed_fields)
                 self.assertNotEqual(history_data[0]['author'], history_data[1]['author'])
+
+            # ------------------------------- customer_fields test ----------------------------------#
+            self.set_user(self.user_1)
+
+            shipment_update_customer_fields = {
+                'customer_fields': {
+                    'custom_field_1': 'value one',
+                    'custom_field_2': 'value two'
+                }
+            }
+
+            response = self.client.patch(url_patch, shipment_update_customer_fields, format='json')
+            self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+            self.assertEqual(response.json()['data']['attributes']['customer_fields'], shipment_update_customer_fields['customer_fields'])
+
+            response = self.client.get(history_url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            history_data = response.json()['data']
+            changed_fields = self.get_changed_fields(history_data[0]['fields'], 'field')
+            self.assertTrue('customer_fields.custom_field_1' in changed_fields)
+            self.assertTrue('customer_fields.custom_field_2' in changed_fields)
+
+            # Enum representation test
+            shipment_action_url = reverse('shipment-actions', kwargs={'version': 'v1', 'shipment_pk': shipment_id})
+
+            shipment_action = {
+                'action_type': 'Pick_up'
+            }
+
+            response = self.client.post(shipment_action_url, shipment_action, format='json')
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            data = response.json()['data']
+            self.assertEqual(data['attributes']['state'], 'IN_TRANSIT')
+
+            response = self.client.get(history_url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            history_data = response.json()['data']
+            changed_fields = self.get_changed_fields(history_data[0]['fields'], 'field')
+            self.assertTrue('state' in changed_fields)
+            self.assertTrue('pickup_act' in changed_fields)
+            for change in history_data[0]['fields']:
+                if change['field'] == 'state':
+                    # Enum field value should be in their character representation
+                    assert change['new'] == 'IN_TRANSIT'
 
             # ------------------------------- datetime filtering test -------------------------------#
             self.set_user(self.user_1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -88,3 +88,9 @@ def datetimeAlmostEqual(dt1, dt2=None):
     if not dt2:
         dt2 = datetime.now().replace(tzinfo=pytz.UTC)
     return dt1.replace(second=0, microsecond=0) == dt2.replace(second=0, microsecond=0)
+
+
+class GeoCoderResponse:
+    def __init__(self, status, point=None):
+        self.ok = status
+        self.xy = point


### PR DESCRIPTION
This `PR` addresses mainly the support for `Shipment.customer_fields` and enum representation in historical shipment responses.

- Added support for `JsonField` 

- Added support for enum values representation

- Removed `version` and `geometry` fields from responses

- Added additional tests