### PR TITLE
Remove outer `transaction.atomic` in AsyncTask get/sign/send flow

### DIFF
--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -104,7 +104,13 @@ class AsyncTask:
         LOG.debug(f'Sending transaction for job {self.async_job.id}, hash {eth_action.transaction_hash}')
         log_metric('transmission.info', tags={'method': 'async_task._send_transaction', 'module': __name__})
 
-        receipt = getattr(self.rpc_client, 'send_transaction')(signed_tx, self.async_job.get_callback_url())
+        try:
+            receipt = getattr(self.rpc_client, 'send_transaction')(signed_tx, self.async_job.get_callback_url())
+        except RPCError as exc:
+            # If Transaction submission fails, we want _sign_transaction to succeed next time
+            eth_action.delete()
+            raise exc
+
         with transaction.atomic():
             eth_action.transactionreceipt = TransactionReceipt.from_eth_receipt(receipt)
             eth_action.transactionreceipt.save()

--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -45,8 +45,7 @@ class AsyncTask:
                 try:
                     LOG.debug(f'Lock on {wallet_id} acquired, attempting to send transaction')
                     self.async_job.wallet_lock_token = wallet_lock.local.token.decode()
-                    with transaction.atomic():
-                        self._send_transaction(*self._sign_transaction(self._get_transaction()))
+                    self._send_transaction(*self._sign_transaction(self._get_transaction()))
                 except Exception as exc:
                     # If there was an exception, release the lock and re-raise
                     wallet_lock.release()


### PR DESCRIPTION
This PR addresses a pretty common scenario in which Engine gets notified of Transaction Events prior to the notification of the block mining (which is when the TransactionReceipt is returned to Transmission and the `AsyncTask._send_transaction()` method returns).

Because `AsyncTask._sign_transaction()` was in the same `transaction.atomic()` block as `_send_transaction`, there would be no record of the EthAction (created in `_sign_transaction`) when Engine posted Event callbacks to Transmission.

This record removes the outer `transaction.atomic()` block, but leaves the atomic transactions in both the `_sign_transaction` and `_send_transaction` methods. I believe this stays true to the original intention of these methods, and I am struggling to think of any edge cases that this may open up.