### PR TITLE
Add version to engine subscriptions

### DIFF
--- a/apps/eth/rpc.py
+++ b/apps/eth/rpc.py
@@ -10,18 +10,17 @@ LOG = logging.getLogger('transmission')
 
 class EventRPCClient(RPCClient):
 
-    def subscribe(self, project, version, url=Event.get_event_subscription_url(), interval=5000,
-                  events=None):
+    def subscribe(self, parameters, url=Event.get_event_subscription_url(), interval=5000, events=None):
         LOG.debug(f'Event subscription with url {url}.')
         log_metric('transmission.info', tags={'method': 'event_rpcclient.subscribe',
                                               'module': __name__})
 
         result = self.call('event.subscribe', {
             "url": url,
-            "project": project,
+            "project": parameters['project'],
             "interval": interval,
             "eventNames": events or ["allEvents"],
-            "version": version
+            "version": parameters['version']
         })
 
         if 'success' in result and result['success']:

--- a/apps/eth/rpc.py
+++ b/apps/eth/rpc.py
@@ -10,17 +10,18 @@ LOG = logging.getLogger('transmission')
 
 class EventRPCClient(RPCClient):
 
-    def subscribe(self, parameters, url=Event.get_event_subscription_url(), interval=5000, events=None):
+    # pylint:disable=too-many-arguments
+    def subscribe(self, project, version, url=Event.get_event_subscription_url(), interval=5000, events=None):
         LOG.debug(f'Event subscription with url {url}.')
         log_metric('transmission.info', tags={'method': 'event_rpcclient.subscribe',
                                               'module': __name__})
 
         result = self.call('event.subscribe', {
             "url": url,
-            "project": parameters['project'],
+            "project": project,
             "interval": interval,
             "eventNames": events or ["allEvents"],
-            "version": parameters['version']
+            "version": version
         })
 
         if 'success' in result and result['success']:

--- a/apps/eth/rpc.py
+++ b/apps/eth/rpc.py
@@ -10,7 +10,8 @@ LOG = logging.getLogger('transmission')
 
 class EventRPCClient(RPCClient):
 
-    def subscribe(self, project, url=Event.get_event_subscription_url(), interval=5000, events=None):
+    def subscribe(self, project, version, url=Event.get_event_subscription_url(), interval=5000,
+                  events=None):
         LOG.debug(f'Event subscription with url {url}.')
         log_metric('transmission.info', tags={'method': 'event_rpcclient.subscribe',
                                               'module': __name__})
@@ -20,6 +21,7 @@ class EventRPCClient(RPCClient):
             "project": project,
             "interval": interval,
             "eventNames": events or ["allEvents"],
+            "version": version
         })
 
         if 'success' in result and result['success']:

--- a/apps/eth/tasks.py
+++ b/apps/eth/tasks.py
@@ -13,10 +13,13 @@ def engine_subscribe_generic(project, events=None, version=settings.LOAD_VERSION
     from apps.eth.rpc import EventRPCClient, RPCError
     log_metric('transmission.info', tags={'method': f'eth.engine_subscribe_{project.lower()}',
                                           'module': __name__})
-
+    parameters = {
+        'version': version,
+        'project': project
+    }
     try:
         rpc_client = EventRPCClient()
-        rpc_client.subscribe(project=project, events=events, version=version)
+        rpc_client.subscribe(parameters=parameters, events=events)
         LOG.debug(f'Subscribed to {project} events for version {version} successfully with the rpc_client.')
 
     except RPCError as rpc_error:

--- a/conf/base.py
+++ b/conf/base.py
@@ -23,8 +23,8 @@ ENV = environ.Env()
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Versions for engine subscription
-LOAD_VERSION = os.environ.get('LOAD_VERSION', '1.1.0')
-SHIPTOKEN_VERSION = os.environ.get('SHIPTOKEN_VERSION', '1.0.0')
+LOAD_VERSION = '1.1.0'
+SHIPTOKEN_VERSION = '1.0.0'
 
 ENGINE_RPC_URL = os.environ.get('ENGINE_RPC_URL', "http://engine-rpc:2000/")
 INTERNAL_URL = os.environ.get('INTERNAL_URL', 'http://transmission-runserver:8000')

--- a/conf/base.py
+++ b/conf/base.py
@@ -23,8 +23,8 @@ ENV = environ.Env()
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Versions for engine subscription
-LOAD_VERSION = '1.1.0'
-SHIPTOKEN_VERSION = '1.0.0'
+LOAD_VERSION = os.environ.get('LOAD_VERSION', '1.1.0')
+SHIPTOKEN_VERSION = os.environ.get('SHIPTOKEN_VERSION', '1.0.0')
 
 ENGINE_RPC_URL = os.environ.get('ENGINE_RPC_URL', "http://engine-rpc:2000/")
 INTERNAL_URL = os.environ.get('INTERNAL_URL', 'http://transmission-runserver:8000')

--- a/conf/base.py
+++ b/conf/base.py
@@ -22,6 +22,10 @@ ENV = environ.Env()
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+# Versions for engine subscription
+LOAD_VERSION = '1.1.0'
+SHIPTOKEN_VERSION = '1.0.0'
+
 ENGINE_RPC_URL = os.environ.get('ENGINE_RPC_URL', "http://engine-rpc:2000/")
 INTERNAL_URL = os.environ.get('INTERNAL_URL', 'http://transmission-runserver:8000')
 PROFILES_URL = os.environ.get('PROFILES_URL')

--- a/tests/profiles-disabled/test_eth.py
+++ b/tests/profiles-disabled/test_eth.py
@@ -148,7 +148,8 @@ class TransactionReceiptTestCase(APITestCase):
             "url": "URL",
             "project": "LOAD",
             "interval": 5000,
-            "eventNames": ["allEvents"]
+            "eventNames": ["allEvents"],
+            "version": "1.1.0"
         }
         full_params = {
             'jsonrpc': '2.0',
@@ -161,7 +162,7 @@ class TransactionReceiptTestCase(APITestCase):
 
             mock_method.return_value = mocked_rpc_response({'result': {'success': True, 'subscription': params}})
 
-            mock_shipment_rpc.subscribe(project="LOAD", url="URL")
+            mock_shipment_rpc.subscribe(parameters=params, url="URL")
 
             mock_method.assert_called_with(test_settings.ENGINE_RPC_URL, data=json.dumps(full_params))
 

--- a/tests/profiles-disabled/test_eth.py
+++ b/tests/profiles-disabled/test_eth.py
@@ -162,7 +162,7 @@ class TransactionReceiptTestCase(APITestCase):
 
             mock_method.return_value = mocked_rpc_response({'result': {'success': True, 'subscription': params}})
 
-            mock_shipment_rpc.subscribe(parameters=params, url="URL")
+            mock_shipment_rpc.subscribe(project="LOAD", version=test_settings.LOAD_VERSION, url="URL")
 
             mock_method.assert_called_with(test_settings.ENGINE_RPC_URL, data=json.dumps(full_params))
 


### PR DESCRIPTION
This update adds the version to the Engine subscription RPC call, so that transmission can again subscribe to Engine.