### PR TITLE
Add failure for when shipment state supplied is invalid

### DIFF
--- a/apps/shipments/filters.py
+++ b/apps/shipments/filters.py
@@ -5,11 +5,11 @@ from .models import Shipment, TransitState
 
 
 def filter_state(queryset, _, value):
-    # pylint:disable=protected-access
-    if value.upper() not in TransitState._member_names_:
+    try:
+        enum_value = TransitState[value.upper()]
+    except KeyError:
         raise ValidationError('Invalid shipment state supplied.')
 
-    enum_value = TransitState[value.upper()]
     queryset = queryset.filter(**{'state': enum_value.value})
     return queryset
 

--- a/apps/shipments/filters.py
+++ b/apps/shipments/filters.py
@@ -1,9 +1,14 @@
 from django_filters import rest_framework as filters
+from rest_framework_json_api.serializers import ValidationError
 
 from .models import Shipment, TransitState
 
 
 def filter_state(queryset, _, value):
+    # pylint:disable=protected-access
+    if value.upper() not in TransitState._member_names_:
+        raise ValidationError('Invalid shipment state supplied.')
+
     enum_value = TransitState[value.upper()]
     queryset = queryset.filter(**{'state': enum_value.value})
     return queryset

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -183,6 +183,18 @@ class ShipmentAPITests(APITestCase):
         response_data = response.json()
         self.assertEqual(response_data['data'][0]['id'], self.shipments[1].id)
 
+        # Filtering off a shipment state should fail if invalid state supplied
+        response = self.client.get(f'{url}?state=string')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.shipments[1].pick_up()
+        self.shipments[1].save()
+
+        response = self.client.get(f'{url}?state=IN_TRANSIT')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data['data'][0]['id'], self.shipments[1].id)
+
     def test_ordering(self):
         """
         Test filtering for objects


### PR DESCRIPTION
This branch fixes an issue where supplying an invalid shipment state would return a 500 error instead of a 400 error