### PR TITLE
Fix alpine build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 ## Base image with python and entrypoint scripts ##
 ## ============================================= ##
-FROM osgeo/gdal:alpine-ultrasmall-v2.4.1 as gdal
 FROM python:3.6.8-alpine3.10 AS base
 
 LABEL maintainer="Adam Hodges <ahodges@shipchain.io>"
@@ -9,17 +8,14 @@ ENV LANG C.UTF-8
 ENV PYTHONUNBUFFERED 1
 
 # Essential packages for our app environment
-RUN apk add --no-cache bash curl binutils libpq && \
-    apk add --no-cache libcurl libwebp zstd-libs libjpeg-turbo libpng openjpeg libwebp && \
-    rm -f /usr/lib/libturbojpeg.so* /usr/lib/libwebpmux.so* /usr/lib/libwebpdemux.so* /usr/lib/libwebpdecoder.so* && \
-    apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/main/ libcrypto1.1 && \
-    apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ geos && \
+RUN apk add --no-cache bash curl libpq && \
+    apk add --no-cache \
+            --repository http://dl-3.alpinelinux.org/alpine/edge/main/ \
+            --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+            libcrypto1.1 binutils proj-dev gdal geos g++ && \
     curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python && \
     apk del curl
-COPY --from=gdal /usr/share/gdal /usr/share/gdal
-COPY --from=gdal /usr/lib/libgdal.so* /usr/lib/
-COPY --from=gdal /usr/lib/libproj.so* /usr/lib/
-RUN ln -s /usr/lib/libgeos_c.so.1 /usr/local/lib/libgeos_c.so
+RUN ln -s /usr/lib/libgeos_c.so.1 /usr/local/lib/libgeos_c.so && ln -s /usr/lib/libgdal.so.20 /usr/lib/libgdal.so
 
 # Install and configure virtualenv
 RUN pip install virtualenv==16.3.*

--- a/conf/base.py
+++ b/conf/base.py
@@ -302,5 +302,3 @@ if INFLUXDB_URL:
     INFLUXDB_TIMEOUT = 1
 
     EMAIL_BACKEND = 'influxdb_metrics.email.InfluxDbEmailBackend'
-
-GDAL_LIBRARY_PATH = '/usr/lib/libgdal.so'


### PR DESCRIPTION
Another alpine dependency was updated and broke the build, and instead of applying the same workaround to that dep, I figured out the root cause of the issue. The geos/gdal dependencies we use are built on an `edge` version of the g++ compiler, so if we add that to the images base dependencies, the runtime linking errors go away. 
(`OSError: Error relocating /usr/lib/libgdal.so.20: _ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev: symbol not found`)