### PR TITLE
Fix ordering for transaction

### DIFF
--- a/apps/eth/views.py
+++ b/apps/eth/views.py
@@ -106,8 +106,8 @@ class TransactionViewSet(mixins.RetrieveModelMixin,
                     try:
                         permission_link_obj = PermissionLink.objects.get(pk=permission_link)
                     except ObjectDoesNotExist:
-                        LOG.warning(f'User: {self.request.user}, is trying to access a shipment with permission link: '
-                                    f'{permission_link}')
+                        LOG.warning(f'User: {self.request.user}, is trying to access a shipment\'s transactions '
+                                    f'with permission link: {permission_link}')
                         raise PermissionDenied('No permission link found.')
                     queryset = queryset.filter(
                         shipment_owner_access_filter(self.request) | Q(shipment__pk=permission_link_obj.shipment.pk)

--- a/apps/permissions.py
+++ b/apps/permissions.py
@@ -33,6 +33,12 @@ def get_user(request):
     return None, None
 
 
+def shipment_owner_access_filter(request):
+    user_id, organization_id = get_user(request)
+    return Q(shipment__owner_id=organization_id) | Q(shipment__owner_id=user_id) if organization_id else \
+        Q(shipment__owner_id=user_id)
+
+
 def owner_access_filter(request):
     user_id, organization_id = get_user(request)
     return Q(owner_id=organization_id) | Q(owner_id=user_id) if organization_id else Q(owner_id=user_id)

--- a/tests/profiles-enabled/test_eth.py
+++ b/tests/profiles-enabled/test_eth.py
@@ -223,7 +223,6 @@ class TransactionReceiptTestCase(APITestCase):
 
         # An anonymous user with a valid permission link should have access to the shipment's transactions
         response = self.client.get(f'{nested_url}?permission_link={valid_permission_link.id}')
-        print(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()['data']
         self.assertEqual(len(data), 2)

--- a/tests/profiles-enabled/test_eth.py
+++ b/tests/profiles-enabled/test_eth.py
@@ -205,6 +205,12 @@ class TransactionReceiptTestCase(APITestCase):
         response = self.client.get(nested_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        # Ordering works as expected
+        response = self.client.get(f'{nested_url}?ordering=-created_at')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = response.json()
+        self.assertEqual(response_json['data'][0]['attributes']['transaction_hash'], TRANSACTION_HASH_2)
+
         # A Transactions list view cannot be accessed by an anonymous user on a nested route
         self.set_user(None)
 
@@ -217,6 +223,7 @@ class TransactionReceiptTestCase(APITestCase):
 
         # An anonymous user with a valid permission link should have access to the shipment's transactions
         response = self.client.get(f'{nested_url}?permission_link={valid_permission_link.id}')
+        print(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()['data']
         self.assertEqual(len(data), 2)


### PR DESCRIPTION
When listing the transactions for a specific shipment, the ordering of them was not working. This fixes that issue so that the ordering works as intended.