### PR TITLE
Feature shipment documents and shipment imports admin

### DIFF
--- a/apps/admin.py
+++ b/apps/admin.py
@@ -1,3 +1,25 @@
+"""
+Copyright 2019 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+
+from pygments import highlight
+from pygments.lexers import JsonLexer
+from pygments.formatters import HtmlFormatter
+
 from django.utils.html import format_html
 from rest_framework.reverse import reverse
 
@@ -47,3 +69,24 @@ def admin_link(attr, short_description, empty_description="-"):
         return field_func
 
     return wrap
+
+
+class SafeJson(str):
+    def __html__(self):
+        return self
+
+
+def pretty_json_print(field, indent=2, sort_keys=True, lineseparator=u'\n'):
+    response = json.dumps(field, sort_keys=sort_keys, indent=indent)
+
+    # Get the Pygments formatter
+    formatter = HtmlFormatter(style='colorful', lineseparator=lineseparator)
+
+    # Highlight the data
+    response = highlight(response, JsonLexer(), formatter)
+
+    # Get the stylesheet
+    style = "<style>" + formatter.get_style_defs() + "</style><br>"
+
+    # Safe the output
+    return SafeJson(style + response)

--- a/apps/admin.py
+++ b/apps/admin.py
@@ -127,3 +127,14 @@ class ShipmentAdminDisplayMixin:
         return object_detail_admin_link(obj.shipment)
 
     shipment_display.short_description = "Shipment"
+
+
+class NoAddUpdateDeletePermissionMixin:
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/apps/admin.py
+++ b/apps/admin.py
@@ -129,7 +129,7 @@ class ShipmentAdminDisplayMixin:
     shipment_display.short_description = "Shipment"
 
 
-class NoAddUpdateDeletePermissionMixin:
+class NoWritePermissionMixin:
     def has_add_permission(self, request):
         return False
 

--- a/apps/admin.py
+++ b/apps/admin.py
@@ -20,6 +20,7 @@ from pygments import highlight
 from pygments.lexers import JsonLexer
 from pygments.formatters import HtmlFormatter
 
+from django.conf import settings
 from django.utils.html import format_html
 from rest_framework.reverse import reverse
 
@@ -129,7 +130,7 @@ class ShipmentAdminDisplayMixin:
     shipment_display.short_description = "Shipment"
 
 
-class NoWritePermissionMixin:
+class ReadOnlyPermissionMixin:
     def has_add_permission(self, request):
         return False
 
@@ -138,3 +139,7 @@ class NoWritePermissionMixin:
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+
+class AdminPageSizeMixin:
+    list_per_page = settings.ADMIN_PAGE_SIZE

--- a/apps/admin.py
+++ b/apps/admin.py
@@ -92,9 +92,38 @@ def pretty_json_print(field, indent=2, sort_keys=True, lineseparator=u'\n'):
     return SafeJson(style + response)
 
 
-def shipment_admin_link(shipment):
+def object_detail_admin_link(obj):
+    """
+    Returns the url admin link of the object passed in argument
+    """
     return format_html(
         '<a href="{}">{}</a>',
-        admin_change_url(shipment),
-        shipment.id if shipment else ''
+        admin_change_url(obj),
+        obj.id if obj else ''
     )
+
+
+class ShipmentAdminDisplayMixin:
+    """
+    This mixin aims at facilitating the addition of a shipment link on a list
+    or detail page.
+
+    example:
+        class MyModelAdmin(ShipmentAdminDisplayMixin, ModelAdmin):
+            ...
+
+            list_display = (
+                ...
+                'shipment_display',
+            )
+
+            # Or for detail display
+            readonly_fields = (
+                ...
+                'shipment_display',
+            )
+    """
+    def shipment_display(self, obj):
+        return object_detail_admin_link(obj.shipment)
+
+    shipment_display.short_description = "Shipment"

--- a/apps/admin.py
+++ b/apps/admin.py
@@ -90,3 +90,11 @@ def pretty_json_print(field, indent=2, sort_keys=True, lineseparator=u'\n'):
 
     # Safe the output
     return SafeJson(style + response)
+
+
+def shipment_admin_link(shipment):
+    return format_html(
+        '<a href="{}">{}</a>',
+        admin_change_url(shipment),
+        shipment.id if shipment else ''
+    )

--- a/apps/admin.py
+++ b/apps/admin.py
@@ -76,11 +76,11 @@ class SafeJson(str):
         return self
 
 
-def pretty_json_print(field, indent=2, sort_keys=True, lineseparator=u'\n'):
+def pretty_json_print(field, indent=2, sort_keys=True, line_separator=u'\n'):
     response = json.dumps(field, sort_keys=sort_keys, indent=indent)
 
     # Get the Pygments formatter
-    formatter = HtmlFormatter(style='colorful', lineseparator=lineseparator)
+    formatter = HtmlFormatter(style='colorful', lineseparator=line_separator)
 
     # Highlight the data
     response = highlight(response, JsonLexer(), formatter)

--- a/apps/documents/admin.py
+++ b/apps/documents/admin.py
@@ -19,11 +19,11 @@ from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import ShipmentAdminDisplayMixin, NoAddUpdateDeletePermissionMixin
+from apps.admin import ShipmentAdminDisplayMixin, NoWritePermissionMixin
 from .models import Document
 
 
-class ShipmentDocumentAdmin(NoAddUpdateDeletePermissionMixin,
+class ShipmentDocumentAdmin(NoWritePermissionMixin,
                             ShipmentAdminDisplayMixin,
                             admin.ModelAdmin):
     list_per_page = settings.ADMIN_PAGE_SIZE

--- a/apps/documents/admin.py
+++ b/apps/documents/admin.py
@@ -14,19 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from django.conf import settings
 from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import ShipmentAdminDisplayMixin, NoWritePermissionMixin
+from apps.admin import ShipmentAdminDisplayMixin, AdminPageSizeMixin, ReadOnlyPermissionMixin
 from .models import Document
 
 
-class ShipmentDocumentAdmin(NoWritePermissionMixin,
+class ShipmentDocumentAdmin(AdminPageSizeMixin,
+                            ReadOnlyPermissionMixin,
                             ShipmentAdminDisplayMixin,
                             admin.ModelAdmin):
-    list_per_page = settings.ADMIN_PAGE_SIZE
 
     list_display = (
         'id',

--- a/apps/documents/admin.py
+++ b/apps/documents/admin.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from django.conf import settings
 from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
@@ -23,6 +24,7 @@ from .models import Document
 
 
 class ShipmentDocumentAdmin(admin.ModelAdmin):
+    list_per_page = settings.ADMIN_PAGE_SIZE
 
     list_display = (
         'id',

--- a/apps/documents/admin.py
+++ b/apps/documents/admin.py
@@ -19,15 +19,16 @@ from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import shipment_admin_link
+from apps.admin import ShipmentAdminDisplayMixin
 from .models import Document
 
 
-class ShipmentDocumentAdmin(admin.ModelAdmin):
+class ShipmentDocumentAdmin(ShipmentAdminDisplayMixin, admin.ModelAdmin):
     list_per_page = settings.ADMIN_PAGE_SIZE
 
     list_display = (
         'id',
+        'shipment_display',
         'owner_id',
         'document_type',
         'file_type',
@@ -55,11 +56,6 @@ class ShipmentDocumentAdmin(admin.ModelAdmin):
         'owner_id',
         'shipment__id',
     )
-
-    def shipment_display(self, obj):
-        return shipment_admin_link(obj.shipment)
-
-    shipment_display.short_description = "Shipment"
 
     def has_add_permission(self, request):
         return False

--- a/apps/documents/admin.py
+++ b/apps/documents/admin.py
@@ -19,11 +19,13 @@ from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import ShipmentAdminDisplayMixin
+from apps.admin import ShipmentAdminDisplayMixin, NoAddUpdateDeletePermissionMixin
 from .models import Document
 
 
-class ShipmentDocumentAdmin(ShipmentAdminDisplayMixin, admin.ModelAdmin):
+class ShipmentDocumentAdmin(NoAddUpdateDeletePermissionMixin,
+                            ShipmentAdminDisplayMixin,
+                            admin.ModelAdmin):
     list_per_page = settings.ADMIN_PAGE_SIZE
 
     list_display = (
@@ -56,15 +58,6 @@ class ShipmentDocumentAdmin(ShipmentAdminDisplayMixin, admin.ModelAdmin):
         'owner_id',
         'shipment__id',
     )
-
-    def has_add_permission(self, request):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
 
 
 admin.site.register(Document, ShipmentDocumentAdmin)

--- a/apps/documents/admin.py
+++ b/apps/documents/admin.py
@@ -1,0 +1,79 @@
+"""
+Copyright 2019 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from django.contrib import admin
+from django.utils.html import format_html
+from enumfields.admin import EnumFieldListFilter
+from rangefilter.filter import DateRangeFilter
+
+from apps.admin import admin_change_url
+from .models import Document
+
+
+class ShipmentDocumentAdmin(admin.ModelAdmin):
+
+    list_display = (
+        'id',
+        'owner_id',
+        'document_type',
+        'file_type',
+        'upload_status',
+    )
+
+    list_filter = [
+        ('created_at', DateRangeFilter),
+        ('updated_at', DateRangeFilter),
+        ('upload_status', EnumFieldListFilter),
+        ('file_type', EnumFieldListFilter),
+        ('document_type', EnumFieldListFilter),
+    ]
+
+    exclude = ('shipment', )
+
+    readonly_fields = (
+        'shipment_display',
+    )
+
+    search_fields = (
+        'id',
+        'name',
+        'description',
+        'owner_id',
+        'shipment__id',
+    )
+
+    def shipment_display(self, obj):
+        shipment = obj.shipment
+        url = admin_change_url(shipment)
+        return format_html(
+            '<a href="{}">{}</a>',
+            url,
+            shipment.id if shipment else ''
+        )
+
+    shipment_display.short_description = "Shipment"
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+admin.site.register(Document, ShipmentDocumentAdmin)

--- a/apps/documents/admin.py
+++ b/apps/documents/admin.py
@@ -15,11 +15,10 @@ limitations under the License.
 """
 
 from django.contrib import admin
-from django.utils.html import format_html
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import admin_change_url
+from apps.admin import shipment_admin_link
 from .models import Document
 
 
@@ -56,13 +55,7 @@ class ShipmentDocumentAdmin(admin.ModelAdmin):
     )
 
     def shipment_display(self, obj):
-        shipment = obj.shipment
-        url = admin_change_url(shipment)
-        return format_html(
-            '<a href="{}">{}</a>',
-            url,
-            shipment.id if shipment else ''
-        )
+        return shipment_admin_link(obj.shipment)
 
     shipment_display.short_description = "Shipment"
 

--- a/apps/imports/admin.py
+++ b/apps/imports/admin.py
@@ -1,0 +1,65 @@
+"""
+Copyright 2019 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from django.contrib import admin
+from enumfields.admin import EnumFieldListFilter
+from rangefilter.filter import DateRangeFilter
+
+from apps.admin import pretty_json_print
+from .models import ShipmentImport
+
+
+class ShipmentImportsAdmin(admin.ModelAdmin):
+
+    list_display = (
+        'id',
+        'owner_id',
+        'file_type',
+        'upload_status',
+        'processing_status',
+    )
+
+    exclude = ('report', )
+
+    readonly_fields = ('report_display', )
+
+    list_filter = [
+        ('created_at', DateRangeFilter),
+        ('updated_at', DateRangeFilter),
+        ('file_type', EnumFieldListFilter),
+        ('upload_status', EnumFieldListFilter),
+        ('processing_status', EnumFieldListFilter),
+    ]
+
+    search_fields = ('id', 'name', 'description', 'owner_id', 'shipment__id', 'storage_credentials_id',
+                     'shipper_wallet_id', 'carrier_wallet_id', 'owner_id', 'masquerade_id', )
+
+    def report_display(self, obj):
+        return pretty_json_print(obj.report, indent=4, sort_keys=False, lineseparator=u'\n\n')
+
+    report_display.short_description = "Report"
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+admin.site.register(ShipmentImport, ShipmentImportsAdmin)

--- a/apps/imports/admin.py
+++ b/apps/imports/admin.py
@@ -14,17 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from django.conf import settings
 from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import pretty_json_print, NoWritePermissionMixin
+from apps.admin import pretty_json_print, AdminPageSizeMixin, ReadOnlyPermissionMixin
 from .models import ShipmentImport
 
 
-class ShipmentImportsAdmin(NoWritePermissionMixin, admin.ModelAdmin):
-    list_per_page = settings.ADMIN_PAGE_SIZE
+class ShipmentImportsAdmin(AdminPageSizeMixin,
+                           ReadOnlyPermissionMixin,
+                           admin.ModelAdmin):
 
     list_display = (
         'id',

--- a/apps/imports/admin.py
+++ b/apps/imports/admin.py
@@ -19,11 +19,11 @@ from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import pretty_json_print, NoAddUpdateDeletePermissionMixin
+from apps.admin import pretty_json_print, NoWritePermissionMixin
 from .models import ShipmentImport
 
 
-class ShipmentImportsAdmin(NoAddUpdateDeletePermissionMixin, admin.ModelAdmin):
+class ShipmentImportsAdmin(NoWritePermissionMixin, admin.ModelAdmin):
     list_per_page = settings.ADMIN_PAGE_SIZE
 
     list_display = (

--- a/apps/imports/admin.py
+++ b/apps/imports/admin.py
@@ -50,7 +50,7 @@ class ShipmentImportsAdmin(NoAddUpdateDeletePermissionMixin, admin.ModelAdmin):
                      'shipper_wallet_id', 'carrier_wallet_id', 'owner_id', 'masquerade_id', )
 
     def report_display(self, obj):
-        return pretty_json_print(obj.report, indent=4, sort_keys=False, lineseparator=u'\n\n')
+        return pretty_json_print(obj.report, indent=4, sort_keys=False, line_separator=u'\n\n')
 
     report_display.short_description = "Report"
 

--- a/apps/imports/admin.py
+++ b/apps/imports/admin.py
@@ -19,11 +19,11 @@ from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import pretty_json_print
+from apps.admin import pretty_json_print, NoAddUpdateDeletePermissionMixin
 from .models import ShipmentImport
 
 
-class ShipmentImportsAdmin(admin.ModelAdmin):
+class ShipmentImportsAdmin(NoAddUpdateDeletePermissionMixin, admin.ModelAdmin):
     list_per_page = settings.ADMIN_PAGE_SIZE
 
     list_display = (
@@ -53,15 +53,6 @@ class ShipmentImportsAdmin(admin.ModelAdmin):
         return pretty_json_print(obj.report, indent=4, sort_keys=False, lineseparator=u'\n\n')
 
     report_display.short_description = "Report"
-
-    def has_add_permission(self, request):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
 
 
 admin.site.register(ShipmentImport, ShipmentImportsAdmin)

--- a/apps/imports/admin.py
+++ b/apps/imports/admin.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from django.conf import settings
 from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
@@ -23,6 +24,7 @@ from .models import ShipmentImport
 
 
 class ShipmentImportsAdmin(admin.ModelAdmin):
+    list_per_page = settings.ADMIN_PAGE_SIZE
 
     list_display = (
         'id',

--- a/apps/jobs/admin.py
+++ b/apps/jobs/admin.py
@@ -19,7 +19,7 @@ from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import pretty_json_print, ShipmentAdminDisplayMixin
+from apps.admin import pretty_json_print, ShipmentAdminDisplayMixin, NoAddUpdateDeletePermissionMixin
 from .models import AsyncJob, JobState, AsyncAction, Message
 
 
@@ -30,7 +30,7 @@ def retry_attempt(async_job_admin, request, queryset):
         job.fire(delay=job.delay)
 
 
-class MessageInlineTab(admin.TabularInline):
+class MessageInlineTab(NoAddUpdateDeletePermissionMixin, admin.TabularInline):
     model = Message
 
     exclude = (
@@ -47,31 +47,13 @@ class MessageInlineTab(admin.TabularInline):
 
     body_display.short_description = "Body"
 
-    def has_add_permission(self, request, obj=None):
-        return False
 
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
-
-class AsyncActionInlineTab(admin.TabularInline):
+class AsyncActionInlineTab(NoAddUpdateDeletePermissionMixin, admin.TabularInline):
     model = AsyncAction
 
     readonly_fields = (
         'created_at',
     )
-
-    def has_add_permission(self, request, obj=None):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
 
 
 class AsyncJobAdmin(ShipmentAdminDisplayMixin, admin.ModelAdmin):

--- a/apps/jobs/admin.py
+++ b/apps/jobs/admin.py
@@ -19,7 +19,7 @@ from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import pretty_json_print, shipment_admin_link
+from apps.admin import pretty_json_print, ShipmentAdminDisplayMixin
 from .models import AsyncJob, JobState, AsyncAction, Message
 
 
@@ -74,7 +74,7 @@ class AsyncActionInlineTab(admin.TabularInline):
         return False
 
 
-class AsyncJobAdmin(admin.ModelAdmin):
+class AsyncJobAdmin(ShipmentAdminDisplayMixin, admin.ModelAdmin):
     actions = [retry_attempt]
 
     list_per_page = settings.ADMIN_PAGE_SIZE
@@ -117,11 +117,6 @@ class AsyncJobAdmin(admin.ModelAdmin):
     search_fields = [
         'id',
     ]
-
-    def shipment_display(self, obj):
-        return shipment_admin_link(obj.shipment)
-
-    shipment_display.short_description = "Shipment"
 
     def parameters_display(self, obj):
         return pretty_json_print(obj.parameters)

--- a/apps/jobs/admin.py
+++ b/apps/jobs/admin.py
@@ -14,12 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from django.conf import settings
 from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import pretty_json_print, ShipmentAdminDisplayMixin, NoWritePermissionMixin
+from apps.admin import pretty_json_print, AdminPageSizeMixin, ShipmentAdminDisplayMixin, ReadOnlyPermissionMixin
 from .models import AsyncJob, JobState, AsyncAction, Message
 
 
@@ -30,7 +29,7 @@ def retry_attempt(async_job_admin, request, queryset):
         job.fire(delay=job.delay)
 
 
-class MessageInlineTab(NoWritePermissionMixin, admin.TabularInline):
+class MessageInlineTab(ReadOnlyPermissionMixin, admin.TabularInline):
     model = Message
 
     exclude = (
@@ -48,7 +47,7 @@ class MessageInlineTab(NoWritePermissionMixin, admin.TabularInline):
     body_display.short_description = "Body"
 
 
-class AsyncActionInlineTab(NoWritePermissionMixin, admin.TabularInline):
+class AsyncActionInlineTab(ReadOnlyPermissionMixin, admin.TabularInline):
     model = AsyncAction
 
     readonly_fields = (
@@ -56,10 +55,11 @@ class AsyncActionInlineTab(NoWritePermissionMixin, admin.TabularInline):
     )
 
 
-class AsyncJobAdmin(ShipmentAdminDisplayMixin, admin.ModelAdmin):
-    actions = [retry_attempt]
+class AsyncJobAdmin(AdminPageSizeMixin,
+                    ShipmentAdminDisplayMixin,
+                    admin.ModelAdmin):
 
-    list_per_page = settings.ADMIN_PAGE_SIZE
+    actions = [retry_attempt]
 
     exclude = (
         'parameters',

--- a/apps/jobs/admin.py
+++ b/apps/jobs/admin.py
@@ -19,7 +19,7 @@ from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import pretty_json_print, ShipmentAdminDisplayMixin, NoAddUpdateDeletePermissionMixin
+from apps.admin import pretty_json_print, ShipmentAdminDisplayMixin, NoWritePermissionMixin
 from .models import AsyncJob, JobState, AsyncAction, Message
 
 
@@ -30,7 +30,7 @@ def retry_attempt(async_job_admin, request, queryset):
         job.fire(delay=job.delay)
 
 
-class MessageInlineTab(NoAddUpdateDeletePermissionMixin, admin.TabularInline):
+class MessageInlineTab(NoWritePermissionMixin, admin.TabularInline):
     model = Message
 
     exclude = (
@@ -48,7 +48,7 @@ class MessageInlineTab(NoAddUpdateDeletePermissionMixin, admin.TabularInline):
     body_display.short_description = "Body"
 
 
-class AsyncActionInlineTab(NoAddUpdateDeletePermissionMixin, admin.TabularInline):
+class AsyncActionInlineTab(NoWritePermissionMixin, admin.TabularInline):
     model = AsyncAction
 
     readonly_fields = (

--- a/apps/jobs/admin.py
+++ b/apps/jobs/admin.py
@@ -1,37 +1,26 @@
-import json
+"""
+Copyright 2019 ShipChain, Inc.
 
-from pygments import highlight
-from pygments.lexers import JsonLexer
-from pygments.formatters import HtmlFormatter
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
 
 from django.contrib import admin
 from django.utils.html import format_html
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import admin_change_url
+from apps.admin import admin_change_url, pretty_json_print
 from .models import AsyncJob, JobState, AsyncAction, Message
-
-
-class SafeJson(str):
-    def __html__(self):
-        return self
-
-
-def pretty_json_print(field):
-    response = json.dumps(field, sort_keys=True, indent=2)
-
-    # Get the Pygments formatter
-    formatter = HtmlFormatter(style='colorful')
-
-    # Highlight the data
-    response = highlight(response, JsonLexer(), formatter)
-
-    # Get the stylesheet
-    style = "<style>" + formatter.get_style_defs() + "</style><br>"
-
-    # Safe the output
-    return SafeJson(style + response)
 
 
 def retry_attempt(async_job_admin, request, queryset):

--- a/apps/jobs/admin.py
+++ b/apps/jobs/admin.py
@@ -15,11 +15,10 @@ limitations under the License.
 """
 
 from django.contrib import admin
-from django.utils.html import format_html
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
 
-from apps.admin import admin_change_url, pretty_json_print
+from apps.admin import pretty_json_print, shipment_admin_link
 from .models import AsyncJob, JobState, AsyncAction, Message
 
 
@@ -117,13 +116,7 @@ class AsyncJobAdmin(admin.ModelAdmin):
     ]
 
     def shipment_display(self, obj):
-        shipment = obj.shipment
-        url = admin_change_url(shipment)
-        return format_html(
-            '<a href="{}">{}</a>',
-            url,
-            shipment.id if shipment else ''
-        )
+        return shipment_admin_link(obj.shipment)
 
     shipment_display.short_description = "Shipment"
 

--- a/apps/jobs/admin.py
+++ b/apps/jobs/admin.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from django.conf import settings
 from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
 from rangefilter.filter import DateRangeFilter
@@ -75,6 +76,8 @@ class AsyncActionInlineTab(admin.TabularInline):
 
 class AsyncJobAdmin(admin.ModelAdmin):
     actions = [retry_attempt]
+
+    list_per_page = settings.ADMIN_PAGE_SIZE
 
     exclude = (
         'parameters',

--- a/apps/shipments/admin/historical.py
+++ b/apps/shipments/admin/historical.py
@@ -1,5 +1,4 @@
 from django import http
-from django.conf import settings
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import unquote
 from django.contrib.contenttypes.models import ContentType
@@ -13,8 +12,6 @@ from simple_history.admin import SimpleHistoryAdmin, USER_NATURAL_KEY, SIMPLE_HI
 
 
 class BaseModelHistory(SimpleHistoryAdmin):
-    list_per_page = settings.ADMIN_PAGE_SIZE
-
     def history_view(self, request, object_id, extra_context=None):     # pylint:disable=too-many-locals
         request.current_app = self.admin_site.name
         model = self.model

--- a/apps/shipments/admin/historical.py
+++ b/apps/shipments/admin/historical.py
@@ -10,10 +10,10 @@ from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 from simple_history.admin import SimpleHistoryAdmin, USER_NATURAL_KEY, SIMPLE_HISTORY_EDIT
 
-from apps.admin import NoAddUpdateDeletePermissionMixin
+from apps.admin import NoWritePermissionMixin
 
 
-class BaseModelHistory(NoAddUpdateDeletePermissionMixin, SimpleHistoryAdmin):
+class BaseModelHistory(NoWritePermissionMixin, SimpleHistoryAdmin):
     def history_view(self, request, object_id, extra_context=None):     # pylint:disable=too-many-locals
         request.current_app = self.admin_site.name
         model = self.model

--- a/apps/shipments/admin/historical.py
+++ b/apps/shipments/admin/historical.py
@@ -1,4 +1,5 @@
 from django import http
+from django.conf import settings
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import unquote
 from django.contrib.contenttypes.models import ContentType
@@ -12,6 +13,7 @@ from simple_history.admin import SimpleHistoryAdmin, USER_NATURAL_KEY, SIMPLE_HI
 
 
 class BaseModelHistory(SimpleHistoryAdmin):
+    list_per_page = settings.ADMIN_PAGE_SIZE
 
     def history_view(self, request, object_id, extra_context=None):     # pylint:disable=too-many-locals
         request.current_app = self.admin_site.name

--- a/apps/shipments/admin/historical.py
+++ b/apps/shipments/admin/historical.py
@@ -10,8 +10,10 @@ from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 from simple_history.admin import SimpleHistoryAdmin, USER_NATURAL_KEY, SIMPLE_HISTORY_EDIT
 
+from apps.admin import NoAddUpdateDeletePermissionMixin
 
-class BaseModelHistory(SimpleHistoryAdmin):
+
+class BaseModelHistory(NoAddUpdateDeletePermissionMixin, SimpleHistoryAdmin):
     def history_view(self, request, object_id, extra_context=None):     # pylint:disable=too-many-locals
         request.current_app = self.admin_site.name
         model = self.model
@@ -121,12 +123,3 @@ class BaseModelHistory(SimpleHistoryAdmin):
         return render(
             request, self.object_history_form_template, context, **extra_kwargs
         )
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
-    def has_add_permission(self, request):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False

--- a/apps/shipments/admin/historical.py
+++ b/apps/shipments/admin/historical.py
@@ -10,10 +10,10 @@ from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 from simple_history.admin import SimpleHistoryAdmin, USER_NATURAL_KEY, SIMPLE_HISTORY_EDIT
 
-from apps.admin import NoWritePermissionMixin
+from apps.admin import ReadOnlyPermissionMixin
 
 
-class BaseModelHistory(NoWritePermissionMixin, SimpleHistoryAdmin):
+class BaseModelHistory(ReadOnlyPermissionMixin, SimpleHistoryAdmin):
     def history_view(self, request, object_id, extra_context=None):     # pylint:disable=too-many-locals
         request.current_app = self.admin_site.name
         model = self.model

--- a/apps/shipments/admin/shipment.py
+++ b/apps/shipments/admin/shipment.py
@@ -14,20 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from django.conf import settings
 from django.contrib import admin
 from django.utils.html import format_html
 from rangefilter.filter import DateRangeFilter
 
 from apps.shipments.models import Shipment, Location, TransitState
 from apps.jobs.models import AsyncJob
-from apps.admin import object_detail_admin_link, NoWritePermissionMixin
+from apps.admin import object_detail_admin_link, AdminPageSizeMixin, ReadOnlyPermissionMixin
 
 from .filter import StateFilter
 from .historical import BaseModelHistory
 
 
-class AsyncJobInlineTab(NoWritePermissionMixin, admin.TabularInline):
+class AsyncJobInlineTab(ReadOnlyPermissionMixin, admin.TabularInline):
     model = AsyncJob
     fields = (
         'job_id',
@@ -83,8 +82,9 @@ NON_SCHEMA_FIELDS = [
 ]
 
 
-class ShipmentAdmin(NoWritePermissionMixin, admin.ModelAdmin):
-    list_per_page = settings.ADMIN_PAGE_SIZE
+class ShipmentAdmin(AdminPageSizeMixin,
+                    ReadOnlyPermissionMixin,
+                    admin.ModelAdmin):
 
     # Read Only admin page until this feature is worked
     list_display = ('id', 'owner_id', 'shippers_reference', 'created_at', 'updated_at', 'shipment_state', )
@@ -135,8 +135,7 @@ class HistoricalShipmentAdmin(BaseModelHistory, ShipmentAdmin):
     readonly_fields = [field.name for field in Shipment._meta.get_fields()]
 
 
-class LocationAdmin(BaseModelHistory):
-    list_per_page = settings.ADMIN_PAGE_SIZE
+class LocationAdmin(AdminPageSizeMixin, BaseModelHistory):
 
     fieldsets = [(None, {'fields': [field.name for field in Location._meta.local_fields] + ['shipment_display']})]
 

--- a/apps/shipments/admin/shipment.py
+++ b/apps/shipments/admin/shipment.py
@@ -21,13 +21,13 @@ from rangefilter.filter import DateRangeFilter
 
 from apps.shipments.models import Shipment, Location, TransitState
 from apps.jobs.models import AsyncJob
-from apps.admin import object_detail_admin_link, NoAddUpdateDeletePermissionMixin
+from apps.admin import object_detail_admin_link, NoWritePermissionMixin
 
 from .filter import StateFilter
 from .historical import BaseModelHistory
 
 
-class AsyncJobInlineTab(NoAddUpdateDeletePermissionMixin, admin.TabularInline):
+class AsyncJobInlineTab(NoWritePermissionMixin, admin.TabularInline):
     model = AsyncJob
     fields = (
         'job_id',
@@ -83,7 +83,7 @@ NON_SCHEMA_FIELDS = [
 ]
 
 
-class ShipmentAdmin(NoAddUpdateDeletePermissionMixin, admin.ModelAdmin):
+class ShipmentAdmin(NoWritePermissionMixin, admin.ModelAdmin):
     list_per_page = settings.ADMIN_PAGE_SIZE
 
     # Read Only admin page until this feature is worked

--- a/apps/shipments/admin/shipment.py
+++ b/apps/shipments/admin/shipment.py
@@ -17,11 +17,11 @@ limitations under the License.
 from django.conf import settings
 from django.contrib import admin
 from django.utils.html import format_html
-from django.urls import reverse
 from rangefilter.filter import DateRangeFilter
 
 from apps.shipments.models import Shipment, Location, TransitState
 from apps.jobs.models import AsyncJob
+from apps.admin import object_detail_admin_link
 
 from .filter import StateFilter
 from .historical import BaseModelHistory
@@ -53,11 +53,7 @@ class AsyncJobInlineTab(admin.TabularInline):
         return "??"
 
     def job_id(self, obj):
-        return format_html(
-            '<a href="{}" target="_blank">{}</a>',
-            reverse('admin:jobs_asyncjob_change', kwargs={'object_id': obj.id}),
-            obj.id
-        )
+        return object_detail_admin_link(obj)
 
     def has_add_permission(self, request, obj=None):
         return False
@@ -140,6 +136,8 @@ class ShipmentAdmin(admin.ModelAdmin):
 
     def shipment_state(self, obj):
         return TransitState(obj.state).label.upper()
+
+    shipment_state.short_description = 'state'
 
     def has_delete_permission(self, request, obj=None):
         return False

--- a/apps/shipments/admin/shipment.py
+++ b/apps/shipments/admin/shipment.py
@@ -1,3 +1,20 @@
+"""
+Copyright 2019 ShipChain, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from django.conf import settings
 from django.contrib import admin
 from django.utils.html import format_html
 from django.urls import reverse
@@ -80,6 +97,8 @@ NON_SCHEMA_FIELDS = [
 
 
 class ShipmentAdmin(admin.ModelAdmin):
+    list_per_page = settings.ADMIN_PAGE_SIZE
+
     # Read Only admin page until this feature is worked
     list_display = ('id', 'owner_id', 'shippers_reference', 'created_at', 'updated_at', 'shipment_state', )
     fieldsets = (
@@ -137,6 +156,8 @@ class HistoricalShipmentAdmin(BaseModelHistory, ShipmentAdmin):
 
 
 class LocationAdmin(BaseModelHistory):
+    list_per_page = settings.ADMIN_PAGE_SIZE
+
     fieldsets = [(None, {'fields': [field.name for field in Location._meta.local_fields]})]
 
     readonly_fields = [field.name for field in Location._meta.get_fields()]

--- a/conf/base.py
+++ b/conf/base.py
@@ -306,3 +306,5 @@ if INFLUXDB_URL:
     EMAIL_BACKEND = 'influxdb_metrics.email.InfluxDbEmailBackend'
 
 GDAL_LIBRARY_PATH = '/usr/lib/libgdal.so'
+
+ADMIN_PAGE_SIZE = 20


### PR DESCRIPTION
This branch adds documents and shipment import admin views and `DRY` the various admin views.
Here below is the breakdown of the main actions carried out here:
- Added shipment documents admin panel in read only mode
- Added shipment imports admin panel in read only mode
- Moved common codes in `apps.admin` module
- Improved shipment locations view 