### PR TITLE
Fix shipment admin crash with shipmentnote as non schema field

### DIFF
--- a/apps/shipments/admin/shipment.py
+++ b/apps/shipments/admin/shipment.py
@@ -62,6 +62,7 @@ NON_SCHEMA_FIELDS = [
     'loadshipment',
     'trackingdata',
     'document',
+    'shipmentnote',
     'id',
     'owner_id',
     'storage_credentials_id',


### PR DESCRIPTION
This change fixes the crash observed on shipment admin panel due to the reverse relationship `ShipmentNote` not excluded from the field set, see comment on link below:

https://github.com/django/django/blob/master/django/contrib/admin/utils.py#L287