### PR TITLE
Hotfix: Frontend URL Changes

### DIFF
--- a/conf/base.py
+++ b/conf/base.py
@@ -72,7 +72,7 @@ if ENVIRONMENT in ('PROD', 'DEMO', 'STAGE', 'DEV'):
     else:
         DEBUG = os.environ.get('FORCE_DEBUG', False)
         LOG_LEVEL = os.environ.get('LOG_LEVEL', 'DEBUG')
-        FRONTEND_DOMAIN = 'portal-stage.ops.shipchain.io'
+        FRONTEND_DOMAIN = f'portal-{ENVIRONMENT.lower()}.shipchain.io'
 
     import boto3
     BOTO3_SESSION = boto3.Session(region_name='us-east-1')


### PR DESCRIPTION
There are changes to the way we are handling frontend urls. We've added a DEV environment at portal-dev.shipchain.io, and we're no longer using the ops subdomain for the frontend at portal-stage.shipchain.io.