### PR TITLE
Optimize transactions list endpoint

### DIFF
--- a/apps/eth/serializers.py
+++ b/apps/eth/serializers.py
@@ -3,6 +3,7 @@ from rest_framework_json_api import serializers
 from apps.eth.fields import HASH_REGEX
 from apps.eth.models import Event, EthAction, Transaction, TransactionReceipt
 from apps.jobs.serializers import AsyncJobSerializer
+from apps.shipments.serializers import FKShipmentSerializer
 
 
 class TransactionSerializer(serializers.ModelSerializer):
@@ -136,7 +137,8 @@ class EthActionSerializer(serializers.ModelSerializer):
     included_serializers = {
         'transaction': TransactionSerializer,
         'transaction_receipt': TransactionReceiptSerializer,
-        'async_job': AsyncJobSerializer
+        'async_job': AsyncJobSerializer,
+        'shipment': FKShipmentSerializer
     }
 
     class JSONAPIMeta:

--- a/apps/shipments/serializers/shipment.py
+++ b/apps/shipments/serializers/shipment.py
@@ -110,6 +110,12 @@ class GeofenceListField(serializers.ListField):
         return super().to_internal_value(data)
 
 
+class FKShipmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Shipment
+        fields = ('id',)
+
+
 class ShipmentSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for a shipment object


### PR DESCRIPTION
The transactions endpoint had a number of extraneous DB queries that were bogging things down.

Changes:
* Use rest_framework_json_api view mixins that enable select_for_includes/prefetch_for_includes
* select/prefetch fields where appropriate to minimize query explosions
* Added a FKShipmentSerializer that doesn't reference any fields other than ID, which keeps any related objects (like LoadShipment) from being prefetched by Django.
* There is a bug in rest_framework_json_api where ModelSerializer._get_field_representation doesn't consider resources that are included by default (`__all__`), because the serializer is not passed to get_included_resources. I will be submitting a PR to fix this in rest_framework_json_api. **In the meantime, a workaround is to explicitly add `?include=shipment` to the end of requests to shipment/{id}/transactions**
* There is still an extra Shipment query that is unnecessary, but I've reached the point of diminishing returns in terms of effort. This call is being made by Django RawQuerySet._fetch_all() which seems to always prefetch related fields. So EthAction.shipment is fetched during pagination, when the paginator is manipulating the queryset.

Below are the results of profiling using django-silk.

Before:
![image](https://user-images.githubusercontent.com/856738/76540393-77523f80-6458-11ea-9f97-51052d8df089.png)


After:
![image](https://user-images.githubusercontent.com/856738/76540406-7a4d3000-6458-11ea-9dd3-e06e581d7f56.png)

