### PR TITLE
Address 500 errors thrown by unauthenticated requests

### DIFF
--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -29,7 +29,7 @@ from shipchain_common.viewsets import ActionConfiguration, ConfigurableGenericVi
 
 from apps.authentication import DocsLambdaRequest
 from apps.jobs.models import AsyncActionType
-from apps.permissions import get_owner_id, ShipmentExists, IsOwnerShipperCarrierModerator
+from apps.permissions import get_owner_id, ShipmentExists, IsNestedOwnerShipperCarrierModerator
 from apps.utils import UploadStatus
 from .filters import DocumentFilterSet
 from .models import Document
@@ -53,7 +53,7 @@ class DocumentViewSet(mixins.ConfigurableCreateModelMixin,
         (permissions.IsAuthenticated,
          ShipmentExists,
          HasViewSetActionPermissions,
-         IsOwnerShipperCarrierModerator, ) if settings.PROFILES_ENABLED
+         IsNestedOwnerShipperCarrierModerator, ) if settings.PROFILES_ENABLED
         else (permissions.AllowAny, ShipmentExists, )
     )
 

--- a/apps/permissions.py
+++ b/apps/permissions.py
@@ -18,7 +18,6 @@ import logging
 
 from django.db.models import Q
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist
 
 from rest_framework import permissions, status
 from shipchain_common.authentication import get_jwt_from_request
@@ -80,12 +79,7 @@ def shipment_exists(shipment_id):
     Check whether a shipment_id included in a nested route exists.
     Returns False if it isn't otherwise returns the Shipment object
     """
-    try:
-        shipment_obj = Shipment.objects.get(pk=shipment_id)
-    except ObjectDoesNotExist:
-        return False
-
-    return shipment_obj
+    return Shipment.objects.filter(id=shipment_id).first()
 
 
 class IsOwner(permissions.BasePermission):
@@ -160,11 +154,11 @@ class IsModeratorMixin:
         return False
 
 
-class IsOwnerShipperCarrierModerator(IsShipmentOwnerMixin,
-                                     IsCarrierMixin,
-                                     IsModeratorMixin,
-                                     IsShipperMixin,
-                                     permissions.BasePermission):
+class IsNestedOwnerShipperCarrierModerator(IsShipmentOwnerMixin,
+                                           IsCarrierMixin,
+                                           IsModeratorMixin,
+                                           IsShipperMixin,
+                                           permissions.BasePermission):
     """
     Custom permission to only allow owner, shipper, moderator and carrier
     access to a shipment object on a nested route

--- a/apps/shipments/views/note.py
+++ b/apps/shipments/views/note.py
@@ -21,7 +21,7 @@ from shipchain_common import mixins
 from shipchain_common.permissions import HasViewSetActionPermissions
 from shipchain_common.viewsets import ActionConfiguration, ConfigurableGenericViewSet
 
-from apps.permissions import ShipmentExists, IsOwnerShipperCarrierModerator
+from apps.permissions import ShipmentExists, IsNestedOwnerShipperCarrierModerator
 from ..models import ShipmentNote
 from ..serializers import ShipmentNoteSerializer, ShipmentNoteCreateSerializer
 
@@ -39,7 +39,7 @@ class ShipmentNoteViewSet(mixins.ConfigurableCreateModelMixin,
         (permissions.IsAuthenticated,
          ShipmentExists,
          HasViewSetActionPermissions,
-         IsOwnerShipperCarrierModerator, ) if settings.PROFILES_ENABLED else
+         IsNestedOwnerShipperCarrierModerator, ) if settings.PROFILES_ENABLED else
         (permissions.AllowAny, ShipmentExists, )
     )
 

--- a/apps/shipments/views/permission_link.py
+++ b/apps/shipments/views/permission_link.py
@@ -23,7 +23,7 @@ from rest_framework.response import Response
 from shipchain_common.exceptions import AWSIoTError, URLShortenerError
 from shipchain_common.utils import send_templated_email
 
-from apps.permissions import ShipmentExists, IsOwnerShipperCarrierModerator
+from apps.permissions import ShipmentExists, IsNestedOwnerShipperCarrierModerator
 from ..iot_client import URLShortener
 from ..models import PermissionLink
 from ..serializers import PermissionLinkSerializer, PermissionLinkCreateSerializer
@@ -40,7 +40,7 @@ class PermissionLinkViewSet(mixins.CreateModelMixin,
     permission_classes = (
         (permissions.IsAuthenticated,
          ShipmentExists,
-         IsOwnerShipperCarrierModerator, ) if settings.PROFILES_ENABLED
+         IsNestedOwnerShipperCarrierModerator, ) if settings.PROFILES_ENABLED
         else (permissions.AllowAny, ShipmentExists, )
     )
     serializer_class = PermissionLinkSerializer

--- a/apps/shipments/views/shipment.py
+++ b/apps/shipments/views/shipment.py
@@ -37,7 +37,7 @@ from apps.permissions import owner_access_filter, get_owner_id, IsOwner, Shipmen
 from ..filters import ShipmentFilter, SHIPMENT_SEARCH_FIELDS
 from ..geojson import render_filtered_point_features
 from ..models import Shipment, TrackingData, PermissionLink
-from ..permissions import IsOwnerOrShared, HasShipmentUpdatePermission
+from ..permissions import IsOwnerOrShared, IsOwnerShipperCarrierModerator
 from ..serializers import ShipmentSerializer, ShipmentCreateSerializer, ShipmentUpdateSerializer, \
     ShipmentTxSerializer
 
@@ -47,7 +47,7 @@ LOG = logging.getLogger('transmission')
 UPDATE_PERMISSION_CLASSES = (
     (HasViewSetActionPermissions,
      ShipmentExists,
-     HasShipmentUpdatePermission, ) if settings.PROFILES_ENABLED else (permissions.AllowAny, ShipmentExists, )
+     IsOwnerShipperCarrierModerator,) if settings.PROFILES_ENABLED else (permissions.AllowAny, ShipmentExists,)
 )
 
 RETRIEVE_PERMISSION_CLASSES = (

--- a/apps/shipments/views/shipment_action.py
+++ b/apps/shipments/views/shipment_action.py
@@ -22,7 +22,7 @@ from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.permissions import ShipmentExists, IsOwnerShipperCarrierModerator
+from apps.permissions import ShipmentExists, IsNestedOwnerShipperCarrierModerator
 from ..models import Shipment
 from ..serializers import ShipmentSerializer, ShipmentActionRequestSerializer
 
@@ -34,7 +34,7 @@ class ShipmentActionsView(APIView):
     permission_classes = (
         (permissions.IsAuthenticated,
          ShipmentExists,
-         IsOwnerShipperCarrierModerator,) if settings.PROFILES_ENABLED
+         IsNestedOwnerShipperCarrierModerator,) if settings.PROFILES_ENABLED
         else (permissions.AllowAny, ShipmentExists,)
     )
 

--- a/apps/shipments/views/shipment_overview.py
+++ b/apps/shipments/views/shipment_overview.py
@@ -48,13 +48,15 @@ class ShipmentOverviewListView(ListAPIView):
 
     bbox_filter_field = 'point'
 
-    queryset = TrackingData.objects.filter(shipment__device_id__isnull=False)
-    shipment_queryset = Shipment.objects.filter(device_id__isnull=False)
+    tracking_data_queryset = TrackingData.objects.filter(shipment__device_id__isnull=False)
+    # The filterset_class and queryset objects should be of the same class instance
+    # to avoid assertion error to be raised by rest_framework.backends
+    queryset = Shipment.objects.filter(device_id__isnull=False)
 
     def filter_tracking_data_queryset(self, owner_id, queryset):
 
         # Shipment owner filter
-        shipment_queryset = self.shipment_queryset.filter(owner_id=owner_id)
+        shipment_queryset = self.get_queryset().filter(owner_id=owner_id)
 
         # Shipment fields filter
         shipment_queryset = self.filter_queryset(shipment_queryset)
@@ -82,7 +84,7 @@ class ShipmentOverviewListView(ListAPIView):
         param_serializer = QueryParamsSerializer(data=request.query_params)
         param_serializer.is_valid(raise_exception=True)
 
-        queryset = self.filter_tracking_data_queryset(owner_id, self.queryset)
+        queryset = self.filter_tracking_data_queryset(owner_id, self.tracking_data_queryset)
 
         paginator = self.pagination_class()
         page = paginator.paginate_queryset(queryset, request, view=self)

--- a/apps/shipments/views/tags.py
+++ b/apps/shipments/views/tags.py
@@ -20,7 +20,7 @@ from shipchain_common import mixins
 from shipchain_common.permissions import HasViewSetActionPermissions
 from shipchain_common.viewsets import ActionConfiguration, ConfigurableGenericViewSet
 
-from apps.permissions import ShipmentExists, IsOwnerShipperCarrierModerator
+from apps.permissions import ShipmentExists, IsNestedOwnerShipperCarrierModerator
 from ..models import ShipmentTag
 from ..serializers import ShipmentTagSerializer, ShipmentTagCreateSerializer
 
@@ -36,7 +36,7 @@ class ShipmentTagViewSet(mixins.ConfigurableCreateModelMixin,
         (permissions.IsAuthenticated,
          ShipmentExists,
          HasViewSetActionPermissions,
-         IsOwnerShipperCarrierModerator, ) if settings.PROFILES_ENABLED else
+         IsNestedOwnerShipperCarrierModerator, ) if settings.PROFILES_ENABLED else
         (permissions.AllowAny, ShipmentExists, )
     )
 

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 from django.views.generic import TemplateView
 from rest_framework.urlpatterns import format_suffix_patterns
@@ -52,19 +52,15 @@ nested_router.register(r'tags', shipments.ShipmentTagViewSet, base_name='shipmen
 nested_router.register(r'telemetry', shipments.TelemetryViewSet, base_name='shipment-telemetry')
 
 urlpatterns = [
-    url('health', management.health_check, name='health'),
-    url(
-        r'(^(api/v1/schema)|^$)',
-        TemplateView.as_view(template_name='apidoc.html'),
-        name='api_schema'
-    ),
-    url(r'^admin/', admin.site.urls),
-    url(f'{API_PREFIX[1:]}/documents/events', documents.S3Events.as_view(), name='document-events'),
-    url(f'{API_PREFIX[1:]}/devices/status/', shipments.ShipmentOverviewListView.as_view(), name='devices-status'),
-    url(f'{API_PREFIX[1:]}/shipments/overview/', shipments.ShipmentOverviewListView.as_view(),
-        name='shipments-overview'),
-    url(f'{API_PREFIX[1:]}/shipments/(?P<shipment_pk>[0-9a-f-]+)/actions',
-        shipments.ShipmentActionsView.as_view(), name='shipment-actions'),
+    re_path('health/?$', management.health_check, name='health'),
+    re_path(r'(^(api/v1/schema)|^$)', TemplateView.as_view(template_name='apidoc.html'), name='api_schema'),
+    re_path(r'^admin/', admin.site.urls),
+    re_path(f'{API_PREFIX[1:]}/documents/events/?$', documents.S3Events.as_view(), name='document-events'),
+    re_path(f'{API_PREFIX[1:]}/devices/status/?$', shipments.ShipmentOverviewListView.as_view(), name='devices-status'),
+    re_path(f'{API_PREFIX[1:]}/shipments/overview/?$', shipments.ShipmentOverviewListView.as_view(),
+            name='shipments-overview'),
+    re_path(f'{API_PREFIX[1:]}/shipments/(?P<shipment_pk>[0-9a-f-]+)/actions/?$',
+            shipments.ShipmentActionsView.as_view(), name='shipment-actions'),
 ]
 urlpatterns += router.urls
 

--- a/tests/profiles-enabled/shipments/permission-link/test_permission_link.py
+++ b/tests/profiles-enabled/shipments/permission-link/test_permission_link.py
@@ -272,7 +272,7 @@ class TestPermissionLinkShipmentAccess:
         response = api_client.get(self.url_valid_permission)
         AssertionHelper.HTTP_200(response, entity_refs=self.entity_ref_shipment_alice)
 
-    def test_can_access_with_ownership(self, api_client):
+    def test_can_access_without_jwt(self, api_client):
         response = api_client.get(self.url_valid_permission)
         AssertionHelper.HTTP_200(response, entity_refs=self.entity_ref_shipment_alice)
 
@@ -284,8 +284,8 @@ class TestPermissionLinkShipmentAccess:
         response = client_alice.get(self.url_expired_permission)
         AssertionHelper.HTTP_200(response, entity_refs=self.entity_ref_shipment_alice)
 
-    def test_wallet_owner_access_expired_link(self, api_client, mock_successful_wallet_owner_calls, profiles_ids):
-        response = api_client.get(self.url_expired_permission)
+    def test_wallet_owner_access_expired_link(self, client_bob, mock_successful_wallet_owner_calls, profiles_ids):
+        response = client_bob.get(self.url_expired_permission)
         AssertionHelper.HTTP_200(response, entity_refs=self.entity_ref_shipment_alice)
         self.successful_wallet_owner_calls_assertions.append({
             'host': settings.PROFILES_URL.replace('http://', ''),
@@ -293,13 +293,13 @@ class TestPermissionLinkShipmentAccess:
         })
         mock_successful_wallet_owner_calls.assert_calls(self.successful_wallet_owner_calls_assertions)
 
-    def test_non_owner_expired_link_fails(self, api_client, mock_non_wallet_owner_calls):
-        response = api_client.get(self.url_expired_permission)
+    def test_non_owner_expired_link_fails(self, client_bob, mock_non_wallet_owner_calls):
+        response = client_bob.get(self.url_expired_permission)
         AssertionHelper.HTTP_403(response)
         mock_non_wallet_owner_calls.assert_calls(self.nonsuccessful_wallet_owner_calls_assertions)
 
-    def test_cannot_delete_with_permission_link(self, api_client):
-        response = api_client.delete(self.url_valid_permission)
+    def test_cannot_delete_with_permission_link(self, client_bob):
+        response = client_bob.delete(self.url_valid_permission)
         AssertionHelper.HTTP_403(response)
 
     def test_owner_can_delete_with_permission_link(self, client_alice):
@@ -312,8 +312,8 @@ class TestPermissionLinkShipmentAccess:
 
         AssertionHelper.HTTP_202(response, entity_refs=self.entity_ref_shipment_alice)
 
-    def test_requires_shipment_relationship(self, api_client, mock_non_wallet_owner_calls):
-        response = api_client.get(self.url_wrong_permission)
+    def test_requires_shipment_relationship(self, client_bob, mock_non_wallet_owner_calls):
+        response = client_bob.get(self.url_wrong_permission)
         AssertionHelper.HTTP_403(response)
         mock_non_wallet_owner_calls.assert_calls(self.nonsuccessful_wallet_owner_calls_assertions)
 

--- a/tests/profiles-enabled/shipments/permission-link/test_permission_link.py
+++ b/tests/profiles-enabled/shipments/permission-link/test_permission_link.py
@@ -287,10 +287,6 @@ class TestPermissionLinkShipmentAccess:
     def test_wallet_owner_access_expired_link(self, client_bob, mock_successful_wallet_owner_calls, profiles_ids):
         response = client_bob.get(self.url_expired_permission)
         AssertionHelper.HTTP_200(response, entity_refs=self.entity_ref_shipment_alice)
-        self.successful_wallet_owner_calls_assertions.append({
-            'host': settings.PROFILES_URL.replace('http://', ''),
-            'path': f'/api/v1/wallet/{profiles_ids["shipper_wallet_id"]}/'
-        })
         mock_successful_wallet_owner_calls.assert_calls(self.successful_wallet_owner_calls_assertions)
 
     def test_non_owner_expired_link_fails(self, client_bob, mock_non_wallet_owner_calls):
@@ -314,8 +310,7 @@ class TestPermissionLinkShipmentAccess:
 
     def test_requires_shipment_relationship(self, client_bob, mock_non_wallet_owner_calls):
         response = client_bob.get(self.url_wrong_permission)
-        AssertionHelper.HTTP_403(response)
-        mock_non_wallet_owner_calls.assert_calls(self.nonsuccessful_wallet_owner_calls_assertions)
+        AssertionHelper.HTTP_404(response)
 
     def test_owner_wrong_permission(self, client_alice, entity_ref_shipment_alice_two):
         response = client_alice.get(self.url_wrong_permission)


### PR DESCRIPTION
The changes in this branch aim at addressing the 500 errors thrown when an unauthenticated request hit some endpoints.
Until now this situation hasn't emerged in any of our unit tests because most of the errors involved result from real responses from profiles and couldn't being noticed in unit tests. 
With these changes, non authenticated requests will no longer hit endpoints such as `/wallet/{wallet_id}/?is_active`, reducing the chance of unhandled errors on both services.