### PR TITLE
Fix profiles disabled logging error on Transmission

### DIFF
--- a/conf/custom_logging.py
+++ b/conf/custom_logging.py
@@ -7,8 +7,7 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'celery-style': {
-            'format': "[user:%(user_id)s Org:%(organization_id)s %(asctime)s: %(levelname)s/%(processName)s "
-                      "%(filename)s:%(lineno)d] %(message)s",
+            'format': "[%(asctime)s: %(levelname)s/%(processName)s %(filename)s:%(lineno)d] %(message)s",
         },
         'logstash-style': {
             '()': 'logstash_formatter.LogstashFormatter',
@@ -70,6 +69,10 @@ if PROFILES_ENABLED:
 
     # Loggers config
     LOGGING['loggers']['transmission']['filters'].extend(['user_id', 'organization_id'])
+
+    # Add User/Organization to logs:
+    LOGGING['formatters']['celery-style']['format'] = f"[user:%(user_id)s org:%(organization_id)s " \
+                                                      f"{LOGGING['formatters']['celery-style']['format'][1:]}"
 
 
 if BOTO3_SESSION:


### PR DESCRIPTION
This change addresses logging errors that surface when Transmission is run in the `PROFILES_ENABLED=False` mode, by removing the reference to user_id/organization_id when run in this mode.