### PR TITLE
Add load version when creating shipment transaction

### DIFF
--- a/apps/shipments/rpc.py
+++ b/apps/shipments/rpc.py
@@ -158,13 +158,11 @@ class Load110RPCClient(ShipmentRPCClient):
             f'shipper_wallet_id {shipper_wallet_id}, and shipment_id {shipment_id}.')
         log_metric('transmission.info', tags={'method': 'shipment_rpcclient.create_shipment_transaction',
                                               'module': __name__})
-        LOG.info('In create shipment transaction')
 
         result = self.call('load.1.1.0.create_shipment_tx', {
             "senderWallet": shipper_wallet_id,
             "shipmentUuid": shipment_id
         })
-        LOG.info(result)
 
         if 'success' in result and result['success']:
             if 'transaction' in result and 'contractVersion' in result:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def mocked_engine_rpc(mocker):
     mocker.patch('apps.shipments.rpc.Load110RPCClient.add_shipment_data', return_value={'hash': TRANSACTION_HASH})
     mocked_cst = mocker.patch('apps.shipments.rpc.Load110RPCClient.create_shipment_transaction',
                               return_value=('version', {}))
-    mocked_cst.__qualname__ = 'ShipmentRPCClient.create_shipment_transaction'
+    mocked_cst.__qualname__ = 'Load110RPCClient.create_shipment_transaction'
     mocker.patch('apps.shipments.rpc.Load110RPCClient.sign_transaction', return_value=('version', {}))
     mocked_uvht = mocker.patch('apps.shipments.rpc.Load110RPCClient.set_vault_hash_tx', return_value={})
     mocked_uvht.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'

--- a/tests/profiles-disabled/test_eth.py
+++ b/tests/profiles-disabled/test_eth.py
@@ -74,7 +74,7 @@ class TransactionReceiptTestCase(APITestCase):
             return_value=(WALLET_ID, 's3://bucket/' + WALLET_ID))
         mock_shipment_rpc_client.add_shipment_data = mock.Mock(return_value={'hash': 'txHash'})
         mock_shipment_rpc_client.create_shipment_transaction = mock.Mock(return_value=('version', {}))
-        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'ShipmentRPCClient.create_shipment_transaction'
+        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'Load110RPCClient.create_shipment_transaction'
         mock_shipment_rpc_client.sign_transaction = mock.Mock(return_value=({}, 'txHash'))
         mock_shipment_rpc_client.update_vault_hash_transaction = mock.Mock(return_value=({}))
         mock_shipment_rpc_client.update_vault_hash_transaction.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'

--- a/tests/profiles-disabled/test_shipments.py
+++ b/tests/profiles-disabled/test_shipments.py
@@ -7,7 +7,7 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase, APIClient
 from shipchain_common.test_utils import create_form_content, mocked_rpc_response
 
-from apps.shipments.rpc import ShipmentRPCClient
+from apps.shipments.rpc import ShipmentRPCClient, Load110RPCClient
 from apps.shipments.models import Location, Shipment
 
 
@@ -75,12 +75,12 @@ class ShipmentAPITests(APITestCase):
                 '''
 
         # Mock RPC calls
-        mock_shipment_rpc_client = ShipmentRPCClient
+        mock_shipment_rpc_client = Load110RPCClient
 
         mock_shipment_rpc_client.create_vault = mock.Mock(return_value=(parameters['_vault_id'], parameters['_vault_uri']))
         mock_shipment_rpc_client.add_shipment_data = mock.Mock(return_value={'hash': 'txHash'})
         mock_shipment_rpc_client.create_shipment_transaction = mock.Mock(return_value=('version', {}))
-        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'ShipmentRPCClient.create_shipment_transaction'
+        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'Load110RPCClient.create_shipment_transaction'
         mock_shipment_rpc_client.sign_transaction = mock.Mock(return_value=({}, 'txHash'))
         mock_shipment_rpc_client.update_vault_hash_transaction = mock.Mock(return_value=({}))
         mock_shipment_rpc_client.update_vault_hash_transaction.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'
@@ -116,12 +116,12 @@ class ShipmentAPITests(APITestCase):
         }
 
         # Mock RPC calls
-        mock_shipment_rpc_client = ShipmentRPCClient
+        mock_shipment_rpc_client = Load110RPCClient
 
         mock_shipment_rpc_client.create_vault = mock.Mock(return_value=(parameters['_vault_id'], parameters['_vault_uri']))
         mock_shipment_rpc_client.add_shipment_data = mock.Mock(return_value={'hash': 'txHash'})
         mock_shipment_rpc_client.create_shipment_transaction = mock.Mock(return_value=('version', {}))
-        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'ShipmentRPCClient.create_shipment_transaction'
+        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'Load110RPCClient.create_shipment_transaction'
         mock_shipment_rpc_client.sign_transaction = mock.Mock(return_value=({}, 'txHash'))
         mock_shipment_rpc_client.update_vault_hash_transaction = mock.Mock(return_value=({}))
         mock_shipment_rpc_client.update_vault_hash_transaction.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'

--- a/tests/profiles-enabled/test_eth.py
+++ b/tests/profiles-enabled/test_eth.py
@@ -1,5 +1,5 @@
-import json
 import datetime
+import json
 from unittest import mock
 
 import httpretty
@@ -13,7 +13,6 @@ from apps.authentication import passive_credentials_auth
 from apps.eth.models import TransactionReceipt, EthAction
 from apps.jobs.models import AsyncJob
 from apps.shipments.models import Shipment, PermissionLink
-from apps.shipments.rpc import Load110RPCClient
 
 BLOCK_HASH = "0x38823cb26b528867c8dbea4146292908f55e1ee7f293685db1df0851d1b93b24"
 BLOCK_NUMBER = 14
@@ -78,156 +77,164 @@ class TransactionReceiptTestCase(APITestCase):
                                                                           eth_action=self.ethActions[1]))
 
     def test_transaction_get(self):
-        mock_shipment_rpc_client = Load110RPCClient
+        with mock.patch('apps.shipments.rpc.ShipmentRPCClient.create_vault') as create_vault, \
+                mock.patch('apps.shipments.rpc.ShipmentRPCClient.add_shipment_data') as add_shipment_data, \
+                mock.patch('apps.shipments.rpc.Load110RPCClient.create_shipment_transaction') as create_shipment_transaction, \
+                mock.patch('apps.shipments.rpc.Load110RPCClient.sign_transaction') as sign_transaction, \
+                mock.patch('apps.shipments.rpc.Load110RPCClient.set_vault_hash_tx') as set_vault_hash_tx, \
+                mock.patch('apps.shipments.rpc.Load110RPCClient.send_transaction') as send_transaction:
 
-        mock_shipment_rpc_client.create_vault = mock.Mock(
-            return_value=(WALLET_ID, 's3://bucket/' + WALLET_ID))
-        mock_shipment_rpc_client.add_shipment_data = mock.Mock(return_value={'hash': 'txHash'})
-        mock_shipment_rpc_client.create_shipment_transaction = mock.Mock(return_value=('version', {}))
-        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'ShipmentRPCClient.create_shipment_transaction'
-        mock_shipment_rpc_client.sign_transaction = mock.Mock(return_value=({}, 'txHash'))
-        mock_shipment_rpc_client.update_vault_hash_transaction = mock.Mock(return_value=({}))
-        mock_shipment_rpc_client.update_vault_hash_transaction.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'
-        mock_shipment_rpc_client.send_transaction = mock.Mock(return_value={
-            "blockHash": "0xccb595947a121e37df8bf689c3f88c6d9c7fb56070c9afda38551540f9e231f7",
-            "blockNumber": 15,
-            "contractAddress": None,
-            "cumulativeGasUsed": 138090,
-            "from": "0x13b1eebb31a1aa2ecaa2ad9e7455df2f717f2143",
-            "gasUsed": 138090,
-            "logs": [],
-            "logsBloom": "0x0000000000",
-            "status": True,
-            "to": "0x25ff5dc79a7c4e34254ff0f4a19d69e491201dd3",
-            "transactionHash": TRANSACTION_HASH,
-            "transactionIndex": 0
-        })
+            create_vault.return_value = (WALLET_ID, 's3://bucket/' + WALLET_ID)
+            add_shipment_data.return_value = {'hash': 'txHash'}
+            create_shipment_transaction.return_value = ('version', {})
+            create_shipment_transaction.__qualname__ = 'Load110RPCClient.create_shipment_transaction'
+            sign_transaction.return_value = ({}, 'txHash')
+            set_vault_hash_tx.return_value = ({})
+            set_vault_hash_tx.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'
+            send_transaction.return_value = {
+                "blockHash": "0xccb595947a121e37df8bf689c3f88c6d9c7fb56070c9afda38551540f9e231f7",
+                "blockNumber": 15,
+                "contractAddress": None,
+                "cumulativeGasUsed": 138090,
+                "from": "0x13b1eebb31a1aa2ecaa2ad9e7455df2f717f2143",
+                "gasUsed": 138090,
+                "logs": [],
+                "logsBloom": "0x0000000000",
+                "status": True,
+                "to": "0x25ff5dc79a7c4e34254ff0f4a19d69e491201dd3",
+                "transactionHash": TRANSACTION_HASH,
+                "transactionIndex": 0
+            }
 
-        listener = Shipment.objects.create(owner_id=USER_ID, carrier_wallet_id=WALLET_ID,
-                                           shipper_wallet_id=WALLET_ID, vault_id=WALLET_ID,
-                                           storage_credentials_id=WALLET_ID)
+            listener = Shipment.objects.create(owner_id=USER_ID, carrier_wallet_id=WALLET_ID,
+                                               shipper_wallet_id=WALLET_ID, vault_id=WALLET_ID,
+                                               storage_credentials_id=WALLET_ID)
 
-        self.createAsyncJobs(listener)
-        self.createEthAction(listener)
-        self.createTransactionReceipts()
+            self.createAsyncJobs(listener)
+            self.createEthAction(listener)
+            self.createTransactionReceipts()
 
-        url = reverse('transaction-detail', kwargs={'pk': TRANSACTION_HASH, 'version': 'v1'})
+            url = reverse('transaction-detail', kwargs={'pk': TRANSACTION_HASH, 'version': 'v1'})
 
-        self.set_user(self.user_1)
-        response = self.client.get(url)
-        response_json = response.json()
+            self.set_user(self.user_1)
+            response = self.client.get(url)
+            response_json = response.json()
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_json['included'][1]['attributes']['from_address'], FROM_ADDRESS)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response_json['included'][1]['attributes']['from_address'], FROM_ADDRESS)
 
     def test_transaction_list(self):
-        mock_shipment_rpc_client = Load110RPCClient
+        with mock.patch('apps.shipments.rpc.ShipmentRPCClient.create_vault') as create_vault, \
+                mock.patch('apps.shipments.rpc.ShipmentRPCClient.add_shipment_data') as add_shipment_data, \
+                mock.patch('apps.shipments.rpc.Load110RPCClient.create_shipment_transaction') as create_shipment_transaction, \
+                mock.patch('apps.shipments.rpc.Load110RPCClient.sign_transaction') as sign_transaction, \
+                mock.patch('apps.shipments.rpc.Load110RPCClient.set_vault_hash_tx') as set_vault_hash_tx, \
+                mock.patch('apps.shipments.rpc.Load110RPCClient.send_transaction') as send_transaction:
 
-        mock_shipment_rpc_client.create_vault = mock.Mock(
-            return_value=(WALLET_ID, 's3://bucket/' + WALLET_ID))
-        mock_shipment_rpc_client.add_shipment_data = mock.Mock(return_value={'hash': 'txHash'})
-        mock_shipment_rpc_client.create_shipment_transaction = mock.Mock(return_value=('version', {}))
-        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'ShipmentRPCClient.create_shipment_transaction'
-        mock_shipment_rpc_client.sign_transaction = mock.Mock(return_value=({}, 'txHash'))
-        mock_shipment_rpc_client.update_vault_hash_transaction = mock.Mock(return_value=({}))
-        mock_shipment_rpc_client.update_vault_hash_transaction.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'
-        mock_shipment_rpc_client.send_transaction = mock.Mock(return_value={
-            "blockHash": "0xccb595947a121e37df8bf689c3f88c6d9c7fb56070c9afda38551540f9e231f7",
-            "blockNumber": 15,
-            "contractAddress": None,
-            "cumulativeGasUsed": 138090,
-            "from": "0x13b1eebb31a1aa2ecaa2ad9e7455df2f717f2143",
-            "gasUsed": 138090,
-            "logs": [],
-            "logsBloom": "0x0000000000",
-            "status": True,
-            "to": "0x25ff5dc79a7c4e34254ff0f4a19d69e491201dd3",
-            "transactionHash": TRANSACTION_HASH,
-            "transactionIndex": 0
-        })
+            create_vault.return_value = (WALLET_ID, 's3://bucket/' + WALLET_ID)
+            add_shipment_data.return_value = {'hash': 'txHash'}
+            create_shipment_transaction.return_value = ('version', {})
+            create_shipment_transaction.__qualname__ = 'Load110RPCClient.create_shipment_transaction'
+            sign_transaction.return_value = ({}, 'txHash')
+            set_vault_hash_tx.return_value = ({})
+            set_vault_hash_tx.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'
+            send_transaction.return_value = {
+                "blockHash": "0xccb595947a121e37df8bf689c3f88c6d9c7fb56070c9afda38551540f9e231f7",
+                "blockNumber": 15,
+                "contractAddress": None,
+                "cumulativeGasUsed": 138090,
+                "from": "0x13b1eebb31a1aa2ecaa2ad9e7455df2f717f2143",
+                "gasUsed": 138090,
+                "logs": [],
+                "logsBloom": "0x0000000000",
+                "status": True,
+                "to": "0x25ff5dc79a7c4e34254ff0f4a19d69e491201dd3",
+                "transactionHash": TRANSACTION_HASH,
+                "transactionIndex": 0
+            }
 
-        listener = Shipment.objects.create(owner_id=USER_ID, carrier_wallet_id=WALLET_ID,
-                                           shipper_wallet_id=WALLET_ID, vault_id=WALLET_ID,
-                                           storage_credentials_id=WALLET_ID)
+            listener = Shipment.objects.create(owner_id=USER_ID, carrier_wallet_id=WALLET_ID,
+                                               shipper_wallet_id=WALLET_ID, vault_id=WALLET_ID,
+                                               storage_credentials_id=WALLET_ID)
 
-        valid_permission_link = PermissionLink.objects.create(
-            expiration_date=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1),
-            shipment=listener
-        )
+            valid_permission_link = PermissionLink.objects.create(
+                expiration_date=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1),
+                shipment=listener
+            )
 
-        invalid_permission_link = PermissionLink.objects.create(
-            expiration_date=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=-1),
-            shipment=listener
-        )
+            invalid_permission_link = PermissionLink.objects.create(
+                expiration_date=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=-1),
+                shipment=listener
+            )
 
-        self.createAsyncJobs(listener)
-        self.createEthAction(listener)
-        self.createTransactionReceipts()
+            self.createAsyncJobs(listener)
+            self.createEthAction(listener)
+            self.createTransactionReceipts()
 
-        self.set_user(self.user_1, token=self.token)
+            self.set_user(self.user_1, token=self.token)
 
-        # Ensure two different transaction receipts were created
-        self.assertEqual(TransactionReceipt.objects.count(), 2)
+            # Ensure two different transaction receipts were created
+            self.assertEqual(TransactionReceipt.objects.count(), 2)
 
-        url = reverse('transaction-list', kwargs={'version': 'v1'})
+            url = reverse('transaction-list', kwargs={'version': 'v1'})
 
-        # Request without wallet_address query field should fail
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        # request for specific eth actions using wallet_address should fail
-        response = self.client.get(f'{url}?wallet_address={FROM_ADDRESS}')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        with httpretty.enabled():
-            httpretty.register_uri(httpretty.GET,
-                                   f"{test_settings.PROFILES_URL}/api/v1/wallet/{WALLET_ID}/",
-                                   body=json.dumps({'data': {'attributes': {'address':  FROM_ADDRESS}}}),
-                                   status=status.HTTP_200_OK)
-
-            # request for specific eth actions should only return ones with that from_address
-            response = self.client.get(f'{url}?wallet_id={WALLET_ID}')
-            force_authenticate(response, user=self.user_1, token=self.token)
-            response_json = response.json()
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertEqual(len(response_json['data']), 1)
-
-            httpretty.register_uri(httpretty.GET,
-                                   f"{test_settings.PROFILES_URL}/api/v1/wallet/{WALLET_ID}/",
-                                   status=status.HTTP_401_UNAUTHORIZED)
-
-            # request for specific eth actions should fail if the profiles request fails
-            response = self.client.get(f'{url}?wallet_id={WALLET_ID}')
+            # Request without wallet_address query field should fail
+            response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        # Shipment transactions list
-        nested_url = reverse('shipment-transactions-list', kwargs={'version': 'v1', 'shipment_pk': listener.id})
-        response = self.client.get(nested_url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+            # request for specific eth actions using wallet_address should fail
+            response = self.client.get(f'{url}?wallet_address={FROM_ADDRESS}')
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        # Ordering works as expected
-        response = self.client.get(f'{nested_url}?ordering=-created_at')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_json = response.json()
-        self.assertEqual(response_json['data'][0]['attributes']['transaction_hash'], TRANSACTION_HASH_2)
+            with httpretty.enabled():
+                httpretty.register_uri(httpretty.GET,
+                                       f"{test_settings.PROFILES_URL}/api/v1/wallet/{WALLET_ID}/",
+                                       body=json.dumps({'data': {'attributes': {'address':  FROM_ADDRESS}}}),
+                                       status=status.HTTP_200_OK)
 
-        # A Transactions list view cannot be accessed by an anonymous user on a nested route
-        self.set_user(None)
+                # request for specific eth actions should only return ones with that from_address
+                response = self.client.get(f'{url}?wallet_id={WALLET_ID}')
+                force_authenticate(response, user=self.user_1, token=self.token)
+                response_json = response.json()
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(len(response_json['data']), 1)
 
-        with mock.patch('apps.permissions.IsShipperMixin.has_shipper_permission') as mock_carrier, \
-                mock.patch('apps.permissions.IsCarrierMixin.has_carrier_permission') as mock_shipper:
-            mock_carrier.return_value = False
-            mock_shipper.return_value = False
+                httpretty.register_uri(httpretty.GET,
+                                       f"{test_settings.PROFILES_URL}/api/v1/wallet/{WALLET_ID}/",
+                                       status=status.HTTP_401_UNAUTHORIZED)
 
+                # request for specific eth actions should fail if the profiles request fails
+                response = self.client.get(f'{url}?wallet_id={WALLET_ID}')
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+            # Shipment transactions list
+            nested_url = reverse('shipment-transactions-list', kwargs={'version': 'v1', 'shipment_pk': listener.id})
             response = self.client.get(nested_url)
-            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-            # An anonymous user shouldn't have access to the shipment's transactions with an expired permission link
-            response = self.client.get(f'{nested_url}?permission_link={invalid_permission_link.id}')
-            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+            # Ordering works as expected
+            response = self.client.get(f'{nested_url}?ordering=-created_at')
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response_json = response.json()
+            self.assertEqual(response_json['data'][0]['attributes']['transaction_hash'], TRANSACTION_HASH_2)
 
-        # An anonymous user with a valid permission link should have access to the shipment's transactions
-        response = self.client.get(f'{nested_url}?permission_link={valid_permission_link.id}')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()['data']
-        self.assertEqual(len(data), 2)
+            # A Transactions list view cannot be accessed by an anonymous user on a nested route
+            self.set_user(None)
+
+            with mock.patch('apps.permissions.IsShipperMixin.has_shipper_permission') as mock_carrier, \
+                    mock.patch('apps.permissions.IsCarrierMixin.has_carrier_permission') as mock_shipper:
+                mock_carrier.return_value = False
+                mock_shipper.return_value = False
+
+                response = self.client.get(nested_url)
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+                # An anonymous user shouldn't have access to the shipment's transactions with an expired permission link
+                response = self.client.get(f'{nested_url}?permission_link={invalid_permission_link.id}')
+                self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+            # An anonymous user with a valid permission link should have access to the shipment's transactions
+            response = self.client.get(f'{nested_url}?permission_link={valid_permission_link.id}')
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            data = response.json()['data']
+            self.assertEqual(len(data), 2)

--- a/tests/profiles-enabled/test_rpc_client.py
+++ b/tests/profiles-enabled/test_rpc_client.py
@@ -151,52 +151,6 @@ class TestShipmentRPCClient(TestCase):
             vault_signed = rpc_client.add_tracking_data(STORAGE_CRED_ID, SHIPPER_WALLET_ID, CARRIER_WALLET_ID, '{}')
             self.assertEqual(vault_signed, SHIPPER_WALLET_ID)
 
-    def test_create_shipment_transaction(self):
-
-        rpc_client = ShipmentRPCClient()
-
-        # Error response from RPC Server should return server detail in exception
-        with mock.patch.object(requests.Session, 'post') as mock_method:
-            mock_method.return_value = mocked_rpc_response({
-                "error": {
-                    "code": 1337,
-                    "message": "Error from RPC Server",
-                },
-            })
-            try:
-                rpc_client.create_shipment_transaction(STORAGE_CRED_ID, SHIPPER_WALLET_ID)
-                self.fail("Should have thrown RPC Error")
-            except RPCError as rpc_error:
-                self.assertEqual(rpc_error.status_code, 500)
-                self.assertEqual(rpc_error.detail, 'Error from RPC Server')
-
-            mock_method.return_value = mocked_rpc_response({
-                "result": {
-                    "code": 1337,
-                    "message": "Error from RPC Server",
-                },
-            })
-            try:
-                rpc_client.create_shipment_transaction(STORAGE_CRED_ID, SHIPPER_WALLET_ID)
-                self.fail("Should have thrown RPC Error")
-            except RPCError as rpc_error:
-                self.assertEqual(rpc_error.status_code, 500)
-                self.assertEqual(rpc_error.detail, 'Invalid response from Engine')
-
-            mock_method.return_value = mocked_rpc_response({
-                "jsonrpc": "2.0",
-                "result": {
-                    "success": True,
-                    "transaction": SHIPPER_WALLET_ID,
-                    "contractVersion": "v1"
-                },
-                "id": 0
-            })
-
-            contractVersion, transaction = rpc_client.create_shipment_transaction(STORAGE_CRED_ID, SHIPPER_WALLET_ID)
-            self.assertEqual(contractVersion, "v1")
-            self.assertEqual(transaction, SHIPPER_WALLET_ID)
-
     def test_get_tracking_data(self):
 
         rpc_client = ShipmentRPCClient()
@@ -247,6 +201,53 @@ class TestShipmentRPCClient(TestCase):
 
 
 class TestLoad110RPCClient(TestCase):
+
+    def test_create_shipment_transaction(self):
+
+        rpc_client = Load110RPCClient()
+
+        # Error response from RPC Server should return server detail in exception
+        with mock.patch.object(requests.Session, 'post') as mock_method:
+            mock_method.return_value = mocked_rpc_response({
+                "error": {
+                    "code": 1337,
+                    "message": "Error from RPC Server",
+                },
+            })
+            try:
+                rpc_client.create_shipment_transaction(STORAGE_CRED_ID, SHIPPER_WALLET_ID)
+                # self.fail("Should have thrown RPC Error")
+            except RPCError as rpc_error:
+                self.assertEqual(rpc_error.status_code, 500)
+                self.assertEqual(rpc_error.detail, 'Error from RPC Server')
+
+            mock_method.return_value = mocked_rpc_response({
+                "result": {
+                    "code": 1337,
+                    "message": "Error from RPC Server",
+                },
+            })
+            try:
+                rpc_client.create_shipment_transaction(STORAGE_CRED_ID, SHIPPER_WALLET_ID)
+                # self.fail("Should have thrown RPC Error")
+            except RPCError as rpc_error:
+                self.assertEqual(rpc_error.status_code, 500)
+                self.assertEqual(rpc_error.detail, 'Invalid response from Engine')
+
+            mock_method.return_value = mocked_rpc_response({
+                "jsonrpc": "2.0",
+                "result": {
+                    "success": True,
+                    "transaction": SHIPPER_WALLET_ID,
+                    "contractVersion": "v1"
+                },
+                "id": 0
+            })
+
+            contractVersion, transaction = rpc_client.create_shipment_transaction(STORAGE_CRED_ID, SHIPPER_WALLET_ID)
+            self.assertEqual(contractVersion, "v1")
+            self.assertEqual(transaction, SHIPPER_WALLET_ID)
+
     def test_set_vault_hash_tx(self):
 
         rpc_client = Load110RPCClient()

--- a/tests/profiles-enabled/test_shipments.py
+++ b/tests/profiles-enabled/test_shipments.py
@@ -1223,7 +1223,7 @@ class ShipmentAPITests(APITestCase):
         mock_shipment_rpc_client.create_vault = mock.Mock(return_value=(parameters['_vault_id'], parameters['_vault_uri']))
         mock_shipment_rpc_client.add_shipment_data = mock.Mock(return_value={'hash': 'txHash'})
         mock_shipment_rpc_client.create_shipment_transaction = mock.Mock(return_value=('version', {}))
-        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'ShipmentRPCClient.create_shipment_transaction'
+        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'Load110RPCClient.create_shipment_transaction'
         mock_shipment_rpc_client.sign_transaction = mock.Mock(return_value=({}, 'txHash'))
         mock_shipment_rpc_client.update_vault_hash_transaction = mock.Mock(return_value=({}))
         mock_shipment_rpc_client.update_vault_hash_transaction.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'
@@ -1383,7 +1383,7 @@ class ShipmentAPITests(APITestCase):
         mock_shipment_rpc_client.create_vault = mock.Mock(return_value=(VAULT_ID, 's3://bucket/' + VAULT_ID))
         mock_shipment_rpc_client.add_shipment_data = mock.Mock(return_value={'hash': 'txHash'})
         mock_shipment_rpc_client.create_shipment_transaction = mock.Mock(return_value=('version', {}))
-        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'ShipmentRPCClient.create_shipment_transaction'
+        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'Load110RPCClient.create_shipment_transaction'
         mock_shipment_rpc_client.sign_transaction = mock.Mock(return_value=({}, 'txHash'))
         mock_shipment_rpc_client.update_vault_hash_transaction = mock.Mock(return_value=({}))
         mock_shipment_rpc_client.update_vault_hash_transaction.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'
@@ -1499,7 +1499,7 @@ class ShipmentAPITests(APITestCase):
         mock_shipment_rpc_client.create_vault = mock.Mock(return_value=(parameters['_vault_id'], parameters['_vault_uri']))
         mock_shipment_rpc_client.add_shipment_data = mock.Mock(return_value={'hash': 'txHash'})
         mock_shipment_rpc_client.create_shipment_transaction = mock.Mock(return_value=('version', {}))
-        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'ShipmentRPCClient.create_shipment_transaction'
+        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'Load110RPCClient.create_shipment_transaction'
         mock_shipment_rpc_client.sign_transaction = mock.Mock(return_value=({}, 'txHash'))
         mock_shipment_rpc_client.update_vault_hash_transaction = mock.Mock(return_value=({}))
         mock_shipment_rpc_client.update_vault_hash_transaction.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'

--- a/tests/profiles-enabled/test_throttling.py
+++ b/tests/profiles-enabled/test_throttling.py
@@ -82,7 +82,7 @@ class ShipmentAPITests(APITestCase):
         mock_shipment_rpc_client.create_vault = mock.Mock(return_value=(parameters['_vault_id'], parameters['_vault_uri']))
         mock_shipment_rpc_client.add_shipment_data = mock.Mock(return_value={'hash': 'txHash'})
         mock_shipment_rpc_client.create_shipment_transaction = mock.Mock(return_value=('version', {}))
-        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'ShipmentRPCClient.create_shipment_transaction'
+        mock_shipment_rpc_client.create_shipment_transaction.__qualname__ = 'Load110RPCClient.create_shipment_transaction'
         mock_shipment_rpc_client.sign_transaction = mock.Mock(return_value=({}, 'txHash'))
         mock_shipment_rpc_client.update_vault_hash_transaction = mock.Mock(return_value=({}))
         mock_shipment_rpc_client.update_vault_hash_transaction.__qualname__ = 'ShipmentRPCClient.set_vault_hash_tx'


### PR DESCRIPTION
This branch fixes three issues:

- The mocking of the rpc clients on test_eth
- Moved the `create_shipment_transaction` from ShipmentRPCCLient to Load110RPCClient
- Changed the `create_shipment_transaction` call to use the load version.