### PR TITLE
Docker compose cleanup

### DIFF
--- a/bin/dc
+++ b/bin/dc
@@ -11,4 +11,8 @@ cp $PROJECT_DIR/.githooks/* $PROJECT_DIR/.git/hooks/
 [[ -z "$COMPOSE_PROJECT" ]] && COMPOSE_PROJECT=$(basename $PROJECT_DIR)
 [[ -z "$ROLE" ]] && ROLE=dev
 
-docker-compose -p $COMPOSE_PROJECT -f compose/base-services.yml -f compose/$ROLE.yml "$@"
+COMPOUND_COMPOSE=""
+if [ "$ROLE" != "int" ]; then
+    COMPOUND_COMPOSE="-f compose/base-services.yml"
+fi
+docker-compose -p $COMPOSE_PROJECT $COMPOUND_COMPOSE -f compose/$ROLE.yml "$@"

--- a/bin/dc
+++ b/bin/dc
@@ -11,4 +11,4 @@ cp $PROJECT_DIR/.githooks/* $PROJECT_DIR/.git/hooks/
 [[ -z "$COMPOSE_PROJECT" ]] && COMPOSE_PROJECT=$(basename $PROJECT_DIR)
 [[ -z "$ROLE" ]] && ROLE=dev
 
-docker-compose -p $COMPOSE_PROJECT -f compose/$ROLE.yml "$@"
+docker-compose -p $COMPOSE_PROJECT -f compose/base-services.yml -f compose/$ROLE.yml "$@"

--- a/bin/docker_tests
+++ b/bin/docker_tests
@@ -9,7 +9,12 @@ cd "${0%/*}/.."
 
 echo "Running tests"
 
-bin/dc up -d
+# Always run dc down regardless of success/failure
+trap 'bin/dc down' EXIT
+
+export ROLE=test
+
+bin/dc up -d --remove-orphans
 
 bin/dc exec -T runserver /bin/bash -c '! poetry install --dry-run | grep "Warning: The lock file is not up to date" || (echo "poetry.lock does not match pyproject.toml" && exit 1)'
 
@@ -28,5 +33,3 @@ bin/dc exec -T runserver bandit -r apps
 bin/dc exec -T runserver pytest -p no:cacheprovider --cov=apps --cov-config=.coveragerc --cov-report= tests/profiles-enabled
 
 bin/dc exec -T runserver pytest -p no:cacheprovider --cov=apps --cov-config=.coveragerc --cov-append --ds=conf.test_settings_profiles_disabled tests/profiles-disabled
-
-bin/dc down

--- a/bin/integration_tests
+++ b/bin/integration_tests
@@ -4,13 +4,16 @@ set -e
 
 cd "${0%/*}/.."
 
+# Always run dc down regardless of success/failure
+trap 'bin/dc down' EXIT
+
 docker build --target deploy --tag transmission-django .
 
 export ROLE=int
 
 bin/dc build
 
-bin/dc up -d
+bin/dc up -d --remove-orphans
 
 bin/dc exec profiles-django /wait-for-it.sh localhost:8000 -t 120
 

--- a/bin/pytest
+++ b/bin/pytest
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# magic line to ensure that we're always inside the root of our application,
+# no matter from which directory we'll run script
+# thanks to it we can just enter `./bin/pytest`
+cd "${0%/*}/.."
+
+echo "Running pytest"
+
+# Always run dc down regardless of success/failure
+trap 'bin/dc down' EXIT
+
+export ROLE=test
+
+bin/dc up -d --remove-orphans
+
+bin/dc exec -T runserver pytest -p no:cacheprovider --cov=apps --cov-config=.coveragerc --cov-report= "$@"

--- a/compose/base-services.yml
+++ b/compose/base-services.yml
@@ -1,0 +1,73 @@
+version: '3.4'
+services:
+
+  minio:
+    image: minio/minio
+    ports:
+    - "9090:9000"
+    expose:
+      - '9000'
+    environment:
+    - MINIO_ACCESS_KEY=TEST-DEV-KEY
+    - MINIO_SECRET_KEY=NON-TRIVIAL-SECRETKEY
+    - MINIO_DOMAIN=minio
+    command: server /data --address minio:9000
+
+  redis_db:
+    image: redis
+    expose:
+      - '6379'
+    command: >
+      --requirepass redis_pass --appendonly yes
+
+  psql:
+    ports:
+      - "5432:5432"
+    image: shipchain/postgis:9.6-2.4
+    environment:
+      - POSTGRES_USER=transmission
+      - POSTGRES_PASS=transmission
+      - POSTGRES_HOST=psql
+      - POSTGRES_DBNAME=transmission
+      - ALLOW_IP_RANGE=0.0.0.0/0
+
+  runserver:
+    build:
+      context: ../
+      target: local
+    image: transmission-django-dev
+    command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+    ports:
+      - "8000:8000"
+    networks:
+      default:
+        aliases:
+          - transmission-runserver
+      portal:
+        aliases:
+          - transmission-runserver
+    links:
+      - psql
+      - redis_db
+      - minio
+    volumes:
+      - ../:/app
+      - ./django/pip.cache:/build/pip.volume
+    environment:
+      - PYTHONDONTWRITEBYTECODE=1
+      - ENV
+      - SECRET_KEY
+      - SERVICE=runserver
+      - REDIS_URL
+      - ENGINE_RPC_URL
+      - INTERNAL_URL
+      - PROFILES_URL
+      - ELASTICSEARCH_URL
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - LOG_LEVEL
+      - FORCE_DEBUG
+
+networks:
+  portal:
+    external: true

--- a/compose/base-services.yml
+++ b/compose/base-services.yml
@@ -50,9 +50,6 @@ services:
       - psql
       - redis_db
       - minio
-    volumes:
-      - ../:/app
-      - ./django/pip.cache:/build/pip.volume
     environment:
       - PYTHONDONTWRITEBYTECODE=1
       - ENV

--- a/compose/circleci.yml
+++ b/compose/circleci.yml
@@ -2,21 +2,12 @@ version: '3.4'
 services:
 
   minio:
-    image: minio/minio
     expose:
       - '9000'
     networks:
       - portal
-    environment:
-    - MINIO_ACCESS_KEY=TEST-DEV-KEY
-    - MINIO_SECRET_KEY=NON-TRIVIAL-SECRETKEY
-    - MINIO_DOMAIN=minio
-    command: server /data --address minio:9000
 
   redis_db:
-    image: circleci/redis
-    expose:
-      - '6379'
     networks:
       - portal
     volumes:
@@ -43,14 +34,8 @@ services:
       target: test
     image: transmission-django-test
     command: sh -c 'while sleep 3600; do :; done'
-    ports:
-      - "8000:8000"
     networks:
       - portal
-    links:
-      - psql
-      - redis_db
-      - minio
     environment:
       - PYTHONDONTWRITEBYTECODE=1
       - ENV

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -2,39 +2,15 @@ version: '3.4'
 services:
 
   minio:
-    image: minio/minio
-    ports:
-    - "9090:9000"
-    expose:
-      - '9000'
     volumes:
     - /data/shipchain/transmission/minio/data:/data
     - /data/shipchain/transmission/minio/config:/root/.minio
-    environment:
-    - MINIO_ACCESS_KEY=TEST-DEV-KEY
-    - MINIO_SECRET_KEY=NON-TRIVIAL-SECRETKEY
-    - MINIO_DOMAIN=minio
-    command: server /data --address minio:9000
 
   redis_db:
-    image: redis
-    expose:
-      - '6379'
     volumes:
       - /data/shipchain/transmission/redis:/data
-    command: >
-      --requirepass redis_pass --appendonly yes
 
   psql:
-    ports:
-      - "5432:5432"
-    image: shipchain/postgis:9.6-2.4
-    environment:
-      - POSTGRES_USER=transmission
-      - POSTGRES_PASS=transmission
-      - POSTGRES_HOST=psql
-      - POSTGRES_DBNAME=transmission
-      - ALLOW_IP_RANGE=0.0.0.0/0
     volumes:
       - /data/shipchain/transmission/postgresql:/var/lib/postgresql
 
@@ -151,6 +127,3 @@ services:
     links:
       - celery
       - redis_db
-networks:
-  portal:
-    external: true

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -1,0 +1,39 @@
+version: '3.4'
+services:
+
+  runserver:
+    build:
+      context: ../
+      target: local
+    image: transmission-django-dev
+    command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+    ports:
+      - "8000:8000"
+    networks:
+      default:
+        aliases:
+          - transmission-runserver
+      portal:
+        aliases:
+          - transmission-runserver
+    links:
+      - psql
+      - redis_db
+      - minio
+    volumes:
+      - ../:/app
+      - ./django/pip.cache:/build/pip.volume
+    environment:
+      - PYTHONDONTWRITEBYTECODE=1
+      - ENV
+      - SECRET_KEY
+      - SERVICE=runserver
+      - REDIS_URL
+      - ENGINE_RPC_URL=http://engine-rpc:2000
+      - INTERNAL_URL=http://transmission-runserver:8000
+      - PROFILES_URL #http://profiles-runserver:8000
+      - ELASTICSEARCH_URL
+      - AWS_ACCESS_KEY_ID=TEST-DEV-KEY
+      - AWS_SECRET_ACCESS_KEY=NON-TRIVIAL-SECRETKEY
+      - LOG_LEVEL
+      - FORCE_DEBUG

--- a/conf/base.py
+++ b/conf/base.py
@@ -215,9 +215,6 @@ TEMPLATES = [
 WSGI_APPLICATION = 'apps.wsgi.application'
 ASGI_APPLICATION = 'apps.routing.application'
 
-TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
-TEST_OUTPUT_DIR = 'test-results/unittest/results.xml'
-
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 


### PR DESCRIPTION
This addresses a number of nagging technical debt issues with our local compose config:

- Adds a separate `test` compose ROLE that does not include any services that are unnecessary for unit testing, like celery, smtp or django_shell
- The `test` compose file also does not have volume mappings, so the test DB should be truly ephemeral between runs. A drawback to this is that now migrations have to run before unit tests
- Makes proper use of '--remove-orphans' to ensure that these containers are cleaned up when appropriate
- Added a `bin/dc down` bash trap to ensure that dc down is always run, even if a script exits with a failure (ex: unit test failures)
- Added a `bin/pytest` bin helper that allows for easy testing of individual test files from the CLI
- Removed xmlrunner config from settings - we removed this from the project a long time ago and never cleaned up the settings, which were causing unit test errors in some cases