### PR TITLE
Optimize Shipment overview endpoint

### DIFF
--- a/apps/shipments/serializers/shipment_overview.py
+++ b/apps/shipments/serializers/shipment_overview.py
@@ -57,7 +57,7 @@ class QueryParamsSerializer(serializers.Serializer):
         return None
 
 
-class ShipmentLocationSerializer(serializers.ModelSerializer):
+class TrackingOverviewSerializer(serializers.ModelSerializer):
     point = serializers.SerializerMethodField()
 
     class Meta:

--- a/apps/shipments/serializers/shipment_overview.py
+++ b/apps/shipments/serializers/shipment_overview.py
@@ -18,7 +18,7 @@ import json
 from rest_framework import exceptions
 from rest_framework_json_api import serializers
 
-from ..models import TrackingData
+from ..models import TrackingData, Device
 from ..geojson import SingleFeatureTrackingDataSerializer
 from ..serializers import ShipmentOverviewSerializer
 
@@ -57,6 +57,12 @@ class QueryParamsSerializer(serializers.Serializer):
         return None
 
 
+class FKDeviceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Device
+        fields = ('id',)
+
+
 class TrackingOverviewSerializer(serializers.ModelSerializer):
     point = serializers.SerializerMethodField()
 
@@ -69,6 +75,7 @@ class TrackingOverviewSerializer(serializers.ModelSerializer):
 
     included_serializers = {
         'shipment': ShipmentOverviewSerializer,
+        'device': FKDeviceSerializer
     }
 
     def get_point(self, obj):

--- a/apps/shipments/serializers/shipment_overview.py
+++ b/apps/shipments/serializers/shipment_overview.py
@@ -13,13 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import json
 
 from rest_framework import exceptions
 from rest_framework_json_api import serializers
+from rest_framework_gis import serializers as geo_serializers
 
 from ..models import TrackingData, Device
-from ..geojson import SingleFeatureTrackingDataSerializer
 from ..serializers import ShipmentOverviewSerializer
 
 
@@ -63,8 +62,15 @@ class FKDeviceSerializer(serializers.ModelSerializer):
         fields = ('id',)
 
 
+class TrackingOverviewGeojsonSerializer(geo_serializers.GeoFeatureModelSerializer):
+    class Meta:
+        model = TrackingData
+        fields = ('uncertainty', 'source', 'time')
+        geo_field = 'point'
+
+
 class TrackingOverviewSerializer(serializers.ModelSerializer):
-    point = serializers.SerializerMethodField()
+    point = TrackingOverviewGeojsonSerializer(source='*')
 
     class Meta:
         model = TrackingData
@@ -77,10 +83,3 @@ class TrackingOverviewSerializer(serializers.ModelSerializer):
         'shipment': ShipmentOverviewSerializer,
         'device': FKDeviceSerializer
     }
-
-    def get_point(self, obj):
-        return json.loads(SingleFeatureTrackingDataSerializer().serialize(
-            obj,
-            geometry_field='point',
-            fields=('uncertainty', 'source', 'time')
-        ))

--- a/apps/shipments/views/shipment_overview.py
+++ b/apps/shipments/views/shipment_overview.py
@@ -37,6 +37,9 @@ class ShipmentOverviewListView(jsapi_views.PreloadIncludesMixin,
                                jsapi_views.RelatedMixin,
                                ListAPIView):
     queryset = TrackingData.objects.all()
+    select_for_includes = {
+        '__all__': ['shipment']
+    }
 
     serializer_class = TrackingOverviewSerializer
     permission_classes = (permissions.IsAuthenticated,)

--- a/apps/shipments/views/shipment_overview.py
+++ b/apps/shipments/views/shipment_overview.py
@@ -63,8 +63,8 @@ class ShipmentOverviewListView(jsapi_views.PreloadIncludesMixin,
         # Get latest tracking point for each shipment
         # Borrowed subquery example from https://stackoverflow.com/a/43926433
         queryset = queryset.filter(id=Subquery(
-            TrackingData.objects.filter(shipment=OuterRef('shipment'))
-            .values('shipment').annotate(latest_tracking=Max('created_at')).values('id')[:1]
+            TrackingData.objects.filter(shipment=OuterRef('shipment')).order_by('-timestamp')
+            .values('shipment').annotate(latest_tracking=Max('timestamp')).values('id')[:1]
         ))
 
         if settings.PROFILES_ENABLED:

--- a/apps/shipments/views/shipment_overview.py
+++ b/apps/shipments/views/shipment_overview.py
@@ -16,83 +16,66 @@ limitations under the License.
 
 import logging
 
-from django.db.models import Max
+from django.conf import settings
+from django.db.models import Max, OuterRef, Subquery
 from django_filters.rest_framework import DjangoFilterBackend
-from influxdb_metrics.loader import log_metric
-from rest_framework import filters, permissions, status
+from rest_framework import filters, permissions
 from rest_framework.generics import ListAPIView
-from rest_framework.response import Response
 from rest_framework_gis.filters import InBBoxFilter
+from rest_framework_json_api import views as jsapi_views
 
 from apps.permissions import get_owner_id
-from ..serializers import QueryParamsSerializer, ShipmentLocationSerializer
-from ..models import Shipment, TrackingData
-from ..filters import ShipmentFilter, SHIPMENT_SEARCH_FIELDS
+from ..serializers import QueryParamsSerializer, TrackingOverviewSerializer
+from ..models import TrackingData
+from ..filters import ShipmentOverviewFilter, SHIPMENT_SEARCH_FIELDS
 
 LOG = logging.getLogger('transmission')
 
 
-class ShipmentOverviewListView(ListAPIView):
+class ShipmentOverviewListView(jsapi_views.PreloadIncludesMixin,
+                               jsapi_views.AutoPrefetchMixin,
+                               jsapi_views.RelatedMixin,
+                               ListAPIView):
+    queryset = TrackingData.objects.all()
 
-    permission_classes = (permissions.IsAuthenticated, )
+    serializer_class = TrackingOverviewSerializer
+    permission_classes = (permissions.IsAuthenticated,)
 
-    serializer_class = ShipmentLocationSerializer
-
-    filter_backends = (filters.SearchFilter, filters.OrderingFilter, DjangoFilterBackend,)
-
-    filterset_class = ShipmentFilter
-
-    ordering_fields = ('created_at', )
-
-    search_fields = SHIPMENT_SEARCH_FIELDS
-
+    filter_backends = (InBBoxFilter, filters.SearchFilter, filters.OrderingFilter, DjangoFilterBackend,)
     bbox_filter_field = 'point'
+    search_fields = tuple([f'shipment__{field}' for field in SHIPMENT_SEARCH_FIELDS])
+    ordering_fields = ('shipment__created_at', )
+    filterset_class = ShipmentOverviewFilter
 
-    tracking_data_queryset = TrackingData.objects.filter(shipment__device_id__isnull=False)
-    # The filterset_class and queryset objects should be of the same class instance
-    # to avoid assertion error to be raised by rest_framework.backends
-    queryset = Shipment.objects.filter(device_id__isnull=False)
+    def dispatch(self, request, *args, **kwargs):
+        # pylint:disable=protected-access
+        request.GET._mutable = True  # Make query_params mutable
+        for param in dict(request.GET):
+            # Prepend non-trackingdata search/filter/order query params with 'shipment__' to properly query relation
+            if param not in ('search', 'in_bbox',) and request.GET.getlist(param):
+                request.GET.setlist(f'shipment__{param}', request.GET.pop(param))
+        request.GET._mutable = False  # Make query_params immutable
+        return super().dispatch(request, *args, **kwargs)
 
-    def filter_tracking_data_queryset(self, owner_id, queryset):
+    def get_queryset(self, *args, **kwargs):
+        queryset = super().get_queryset(*args, **kwargs)
 
-        # Shipment owner filter
-        shipment_queryset = self.get_queryset().filter(owner_id=owner_id)
+        # Get latest tracking point for each shipment
+        # Borrowed subquery example from https://stackoverflow.com/a/43926433
+        queryset = queryset.filter(id=Subquery(
+            TrackingData.objects.filter(shipment=OuterRef('shipment'))
+            .values('shipment').annotate(latest_tracking=Max('created_at')).values('id')[:1]
+        ))
 
-        # Shipment fields filter
-        shipment_queryset = self.filter_queryset(shipment_queryset)
+        if settings.PROFILES_ENABLED:
+            # Filter by owner
+            queryset.filter(shipment__owner_id=get_owner_id(self.request))
 
-        latest_tracking = shipment_queryset.annotate(
-            latest_tracking_created=Max('trackingdata__created_at')
-        ).values_list('latest_tracking_created')
-
-        tracking_data_queryset = queryset.filter(shipment__in=shipment_queryset,
-                                                 created_at__in=latest_tracking)
-
-        # The Bbox filter needs to happen here for performance reasons.
-        # tracking_data_queryset at this level contains significantly
-        # less points than if performed with the view filter_queryset
-        bbox_tracking_data_queryset = InBBoxFilter().filter_queryset(self.request, tracking_data_queryset, self)
-
-        return bbox_tracking_data_queryset
+        return queryset
 
     def get(self, request, *args, **kwargs):
-        owner_id = get_owner_id(request)
-
-        LOG.debug(f'Listing shipment with device for [{owner_id}]')
-        log_metric('transmission.info', tags={'method': 'devices.list', 'module': __name__})
-
+        # Validate query parameters with a request serializer
         param_serializer = QueryParamsSerializer(data=request.query_params)
         param_serializer.is_valid(raise_exception=True)
 
-        queryset = self.filter_tracking_data_queryset(owner_id, self.tracking_data_queryset)
-
-        paginator = self.pagination_class()
-        page = paginator.paginate_queryset(queryset, request, view=self)
-
-        if page is not None:
-
-            serializer = self.serializer_class(page, many=True)
-            return paginator.get_paginated_response(serializer.data)
-
-        serializer = self.serializer_class(queryset, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return super().get(request, *args, **kwargs)

--- a/apps/shipments/views/shipment_overview.py
+++ b/apps/shipments/views/shipment_overview.py
@@ -37,11 +37,16 @@ LOG = logging.getLogger('transmission')
 
 class JSONAPIGeojsonRenderer(JSONRenderer):
     # Class that allows a nested serializer to be specified in attributes. For rendering `point` as GeoJSON.
+    # (This allows us to render TrackingOverviewGeojsonSerializer as a JSON API attribute on TrackingOverviewSerializer)
+
+    # Exact copy of django-rest-framework-json-api JSONRenderer with the following lines removed from extract_attributes
+    # https://github.com/django-json-api/django-rest-framework-json-api/blob/9d42d9b7018b08e2df399e598d75f057676b3870/re
+    # st_framework_json_api/renderers.py#L62-L66
     @classmethod
     def extract_attributes(cls, fields, resource):
         """
-                Builds the `attributes` object of the JSON API resource object.
-                """
+        Builds the `attributes` object of the JSON API resource object.
+        """
         data = OrderedDict()
         for field_name, _ in iter(fields.items()):
             # ID is always provided in the root of JSON API so remove it from attributes

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -52,14 +52,13 @@ nested_router.register(r'tags', shipments.ShipmentTagViewSet, base_name='shipmen
 nested_router.register(r'telemetry', shipments.TelemetryViewSet, base_name='shipment-telemetry')
 
 urlpatterns = [
-    re_path('health/?$', management.health_check, name='health'),
+    re_path('health/?', management.health_check, name='health'),
     re_path(r'(^(api/v1/schema)|^$)', TemplateView.as_view(template_name='apidoc.html'), name='api_schema'),
     re_path(r'^admin/', admin.site.urls),
     re_path(f'{API_PREFIX[1:]}/documents/events/?$', documents.S3Events.as_view(), name='document-events'),
-    re_path(f'{API_PREFIX[1:]}/devices/status/?$', shipments.ShipmentOverviewListView.as_view(), name='devices-status'),
     re_path(f'{API_PREFIX[1:]}/shipments/overview/?$', shipments.ShipmentOverviewListView.as_view(),
-            name='shipments-overview'),
-    re_path(f'{API_PREFIX[1:]}/shipments/(?P<shipment_pk>[0-9a-f-]+)/actions/?$',
+            name='shipment-overview'),
+    re_path(f'{API_PREFIX[1:]}/shipments/(?P<shipment_pk>[0-9a-f-]+)/actions/?',
             shipments.ShipmentActionsView.as_view(), name='shipment-actions'),
 ]
 urlpatterns += router.urls

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -52,13 +52,13 @@ nested_router.register(r'tags', shipments.ShipmentTagViewSet, base_name='shipmen
 nested_router.register(r'telemetry', shipments.TelemetryViewSet, base_name='shipment-telemetry')
 
 urlpatterns = [
-    re_path('health/?', management.health_check, name='health'),
+    re_path('health/?$', management.health_check, name='health'),
     re_path(r'(^(api/v1/schema)|^$)', TemplateView.as_view(template_name='apidoc.html'), name='api_schema'),
     re_path(r'^admin/', admin.site.urls),
     re_path(f'{API_PREFIX[1:]}/documents/events/?$', documents.S3Events.as_view(), name='document-events'),
     re_path(f'{API_PREFIX[1:]}/shipments/overview/?$', shipments.ShipmentOverviewListView.as_view(),
             name='shipment-overview'),
-    re_path(f'{API_PREFIX[1:]}/shipments/(?P<shipment_pk>[0-9a-f-]+)/actions/?',
+    re_path(f'{API_PREFIX[1:]}/shipments/(?P<shipment_pk>[0-9a-f-]+)/actions/?$',
             shipments.ShipmentActionsView.as_view(), name='shipment-actions'),
 ]
 urlpatterns += router.urls

--- a/tests/profiles-enabled/test_shipment_overview.py
+++ b/tests/profiles-enabled/test_shipment_overview.py
@@ -275,7 +275,7 @@ def test_latest_tracking(client_alice, tracking_data, shipment_tracking_data):
                                      'properties': {
                                          'source': data_point.source,
                                          'uncertainty': data_point.uncertainty,
-                                         'time': f'{data_point.timestamp.isoformat()[:-3]}Z'
+                                         'time': f'{data_point.timestamp.isoformat()}Z'
                                     }
                                  }}
                              ))

--- a/tests/profiles-enabled/test_shipment_overview.py
+++ b/tests/profiles-enabled/test_shipment_overview.py
@@ -103,6 +103,7 @@ def tracking_data():
 
 @pytest.fixture
 def shipment_tracking_data(shipments_with_device, tracking_data):
+    shipments_with_tracking = []
     for shipment in shipments_with_device:
         device = shipment.device
         if device:
@@ -110,6 +111,7 @@ def shipment_tracking_data(shipments_with_device, tracking_data):
                 in_bbox_data['device'] = device
                 in_bbox_data['shipment'] = shipment
                 TrackingData.objects.create(**in_bbox_data)
+            shipments_with_tracking.append(shipment)
 
     # One shipment with tracking data outside of Bbox
     shipment = shipments_with_device[NUM_DEVICES-1]
@@ -120,12 +122,12 @@ def shipment_tracking_data(shipments_with_device, tracking_data):
         out_of_bbox_data['shipment'] = shipment
         TrackingData.objects.create(**out_of_bbox_data)
 
-    return shipments_with_device
+    return shipments_with_tracking
 
 
 @pytest.mark.django_db
 def test_owner_shipment_device_location(client_alice, api_client, shipment_tracking_data):
-    url = reverse('shipments-overview', kwargs={'version': 'v1'})
+    url = reverse('shipment-overview', kwargs={'version': 'v1'})
 
     # An unauthenticated request should with 403 status code
     response = api_client.get(url)
@@ -136,13 +138,13 @@ def test_owner_shipment_device_location(client_alice, api_client, shipment_track
     response = client_alice.get(url)
     response_data = response.json()
     AssertionHelper.HTTP_200(response, vnd=True, is_list=True)
-    assert response_data['meta']['pagination']['count'] == NUM_DEVICES - 2
-    assert len(response_data['included']) == NUM_DEVICES - 2
+    assert response_data['meta']['pagination']['count'] == len(shipment_tracking_data)
+    assert len(response_data['included']) == NUM_DEVICES - 1
 
 
 @pytest.mark.django_db
 def test_filter_shipment_device_location(client_alice, shipment_tracking_data, json_asserter):
-    url = reverse('shipments-overview', kwargs={'version': 'v1'})
+    url = reverse('shipment-overview', kwargs={'version': 'v1'})
 
     shipment_action_url = reverse('shipment-actions',
                                   kwargs={'version': 'v1', 'shipment_pk': shipment_tracking_data[0].id})
@@ -174,7 +176,7 @@ def test_filter_shipment_device_location(client_alice, shipment_tracking_data, j
     response = client_alice.get(in_bbox_url)
     response_data = response.json()
     AssertionHelper.HTTP_200(response, vnd=True, is_list=True)
-    assert response_data['meta']['pagination']['count'] == NUM_DEVICES - 3
+    assert response_data['meta']['pagination']['count'] == len(shipment_tracking_data)
 
     in_transit_url = f'{url}?state={TransitState.IN_TRANSIT.name.lower()}'
 
@@ -227,7 +229,7 @@ def test_filter_shipment_device_location(client_alice, shipment_tracking_data, j
 
 @pytest.mark.django_db
 def test_bbox_param(client_alice, shipment_tracking_data):
-    url = reverse('shipments-overview', kwargs={'version': 'v1'})
+    url = reverse('shipment-overview', kwargs={'version': 'v1'})
 
     bbox_reversed = BBOX.copy()
     bbox_reversed.reverse()


### PR DESCRIPTION
This includes a number of changes to decrease the response time of the shipment overview endpoint

- Rewrite of overview endpoint, eliminating the use of multiple querysets and in-memory filtering
- Prefetch trackingdata shipments, resulting in a JOIN instead of multiple queries
- Use GeoFeatureModelSerializer in favor of SerializerMethodField, which was re-rendering GeoJSON
- Fix bug where Shipments that have tracking data but no active device are not shown

I only had limited test data available locally (2 shipments each with a handful of tracking data points), but still saw a 55% reduction in overall response time. I am confident that this will result in even higher performance savings for larger amounts of data.

Before:
![image](https://user-images.githubusercontent.com/856738/78928283-54727580-7a6e-11ea-9dff-06fbeebb2bea.png)

After:
![image](https://user-images.githubusercontent.com/856738/78928313-5fc5a100-7a6e-11ea-97c9-dde42ece021e.png)
