### PR TITLE
Optimize Shipment history endpoint

### DIFF
--- a/apps/permissions.py
+++ b/apps/permissions.py
@@ -79,7 +79,7 @@ def shipment_exists(shipment_id):
     Check whether a shipment_id included in a nested route exists.
     Returns False if it isn't otherwise returns the Shipment object
     """
-    return Shipment.objects.filter(id=shipment_id).first()
+    return Shipment.objects.filter(id=shipment_id).count()
 
 
 class IsOwner(permissions.BasePermission):

--- a/apps/shipments/views/history.py
+++ b/apps/shipments/views/history.py
@@ -45,9 +45,11 @@ class ShipmentHistoryListView(viewsets.GenericViewSet):
         LOG.debug(f'Listing shipment history for shipment with id: {kwargs["shipment_pk"]}.')
         log_metric('transmission.info', tags={'method': 'shipment.history', 'module': __name__})
 
-        shipment = Shipment.objects.get(id=kwargs['shipment_pk'])
+        queryset = Shipment.history.select_related(
+            'device', 'ship_from_location', 'ship_to_location', 'final_destination_location', 'bill_to_location'
+        ).filter(id=kwargs['shipment_pk'])
 
-        serializer = ChangesDiffSerializer(shipment.history.all(), request, kwargs['shipment_pk'])
+        serializer = ChangesDiffSerializer(queryset, request, kwargs['shipment_pk'])
 
         queryset = serializer.filter_queryset(serializer.historical_queryset)
 


### PR DESCRIPTION
There is not a lot more room to optimize the Shipment history endpoint without a full rewrite, but I was able to reduce the number of queries in the following ways:

- Modify ShipmentExists permission class to use a .count() query (faster) instead of .get()
- Remove unnecessary Shipment.objects.get query in ShipmentHistoryListView.list
- Add select_related to JOIN Shipment history relations