### PR TITLE
Postgres 9.6 -> 10.11

### DIFF
--- a/compose/base-services.yml
+++ b/compose/base-services.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.6'
 services:
 
   minio:

--- a/compose/base-services.yml
+++ b/compose/base-services.yml
@@ -23,7 +23,7 @@ services:
   psql:
     ports:
       - "5432:5432"
-    image: shipchain/postgis:9.6-2.4
+    image: kartoza/postgis:11.0-2.5
     environment:
       - POSTGRES_USER=transmission
       - POSTGRES_PASS=transmission

--- a/compose/base-services.yml
+++ b/compose/base-services.yml
@@ -23,7 +23,7 @@ services:
   psql:
     ports:
       - "5432:5432"
-    image: kartoza/postgis:11.0-2.5
+    image: kartoza/postgis:10.0-2.4
     environment:
       - POSTGRES_USER=transmission
       - POSTGRES_PASS=transmission

--- a/compose/circleci.yml
+++ b/compose/circleci.yml
@@ -17,6 +17,8 @@ services:
 
   psql:
     image: circleci/postgres:11.1-alpine-postgis-ram
+    tmpfs:
+      - /dev/shm/pgdata/data
     expose:
       - '5432'
     networks:

--- a/compose/circleci.yml
+++ b/compose/circleci.yml
@@ -17,7 +17,7 @@ services:
       --requirepass redis_pass
 
   psql:
-    image: circleci/postgres:11.1-alpine-postgis-ram
+    image: circleci/postgres:10.10-alpine-postgis-ram
     tmpfs:
       - /dev/shm/pgdata/data
     expose:
@@ -29,7 +29,6 @@ services:
       - POSTGRES_PASS=transmission
       - POSTGRES_HOST=psql
       - POSTGRES_DB=transmission
-      - ALLOW_IP_RANGE=0.0.0.0/0
 
   runserver:
     build:

--- a/compose/circleci.yml
+++ b/compose/circleci.yml
@@ -16,7 +16,7 @@ services:
       --requirepass redis_pass
 
   psql:
-    image: circleci/postgres:9.6-alpine-postgis
+    image: circleci/postgres:11.1-alpine-postgis-ram
     expose:
       - '5432'
     networks:

--- a/compose/circleci.yml
+++ b/compose/circleci.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.6'
 services:
 
   minio:
@@ -8,10 +8,11 @@ services:
       - portal
 
   redis_db:
+    image: circleci/redis:alpine
     networks:
       - portal
-    volumes:
-      - /data/shipchain/transmission/redis:/data
+    tmpfs:
+      - /data
     command: >
       --requirepass redis_pass
 

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.6'
 services:
 
   minio:

--- a/compose/int.yml
+++ b/compose/int.yml
@@ -69,8 +69,8 @@ services:
       - PGDATA=/dev/shm/pgdata/data
       # https://www.postgresql.org/docs/11/non-durability.html
       - EXTRA_CONF=fsync = off\nsynchronous_commit = off\nfull_page_writes = off\nbgwriter_lru_maxpages = 0
-      tmpfs:
-        - /dev/shm/pgdata/data
+    tmpfs:
+      - /dev/shm/pgdata/data
 
   redis_db:
     image: redis

--- a/compose/int.yml
+++ b/compose/int.yml
@@ -31,49 +31,40 @@ services:
       GETH_VERBOSITY: 1
 
   profiles_psql:
-    image: kartoza/postgis:11.0-2.5
+    image: circleci/postgres:10.10-alpine-postgis-ram
+    tmpfs:
+      - /dev/shm/pgdata/data
     expose:
       - 5432
     environment:
       POSTGRES_USER: profiles
       POSTGRES_PASS: profiles
       POSTGRES_HOST: profiles_psql
-      POSTGRES_DBNAME: profiles
-      ALLOW_IP_RANGE: 0.0.0.0/0
-      PGDATA: /dev/shm/pgdata/data
-      # https://www.postgresql.org/docs/11/non-durability.html
-      EXTRA_CONF: fsync = off\nsynchronous_commit = off\nfull_page_writes = off\nbgwriter_lru_maxpages = 0
-    tmpfs:
-      - /dev/shm/pgdata/data
+      POSTGRES_DB: profiles
 
   engine_psql:
-    image: sameersbn/postgresql:9.6-2
+    image: circleci/postgres:10.10-alpine-ram
     expose:
       - 5432
     environment:
-      DB_NAME: engine
-      DB_PASS: engine
-      DB_USER: engine
-      DB_EXTENSION: '"uuid-ossp"'
+      POSTGRES_USER: engine
+      POSTGRES_PASS: engine
+      POSTGRES_DB: engine
 
   transmission_psql:
     expose:
       - 5432
-    image: kartoza/postgis:11.0-2.5
+    image: circleci/postgres:10.10-alpine-postgis-ram
+    tmpfs:
+      - /dev/shm/pgdata/data
     environment:
       - POSTGRES_USER=transmission
       - POSTGRES_PASS=transmission
       - POSTGRES_HOST=transmission_psql
       - POSTGRES_DB=transmission
-      - ALLOW_IP_RANGE=0.0.0.0/0
-      - PGDATA=/dev/shm/pgdata/data
-      # https://www.postgresql.org/docs/11/non-durability.html
-      - EXTRA_CONF=fsync = off\nsynchronous_commit = off\nfull_page_writes = off\nbgwriter_lru_maxpages = 0
-    tmpfs:
-      - /dev/shm/pgdata/data
 
   redis_db:
-    image: redis
+    image: circleci/redis:alpine
     tmpfs:
       - /data
     expose:

--- a/compose/int.yml
+++ b/compose/int.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.6'
 services:
   newman:
     image: postman/newman
@@ -40,6 +40,11 @@ services:
       POSTGRES_HOST: profiles_psql
       POSTGRES_DBNAME: profiles
       ALLOW_IP_RANGE: 0.0.0.0/0
+      PGDATA: /dev/shm/pgdata/data
+      # https://www.postgresql.org/docs/11/non-durability.html
+      EXTRA_CONF: fsync = off\nsynchronous_commit = off\nfull_page_writes = off\nbgwriter_lru_maxpages = 0
+    tmpfs:
+      - /dev/shm/pgdata/data
 
   engine_psql:
     image: sameersbn/postgresql:9.6-2
@@ -61,9 +66,16 @@ services:
       - POSTGRES_HOST=transmission_psql
       - POSTGRES_DB=transmission
       - ALLOW_IP_RANGE=0.0.0.0/0
+      - PGDATA=/dev/shm/pgdata/data
+      # https://www.postgresql.org/docs/11/non-durability.html
+      - EXTRA_CONF=fsync = off\nsynchronous_commit = off\nfull_page_writes = off\nbgwriter_lru_maxpages = 0
+      tmpfs:
+        - /dev/shm/pgdata/data
 
   redis_db:
     image: redis
+    tmpfs:
+      - /data
     expose:
       - 6379
     command: >

--- a/compose/int.yml
+++ b/compose/int.yml
@@ -31,7 +31,7 @@ services:
       GETH_VERBOSITY: 1
 
   profiles_psql:
-    image: shipchain/postgis:9.6-2.4
+    image: kartoza/postgis:11.0-2.5
     expose:
       - 5432
     environment:
@@ -54,7 +54,7 @@ services:
   transmission_psql:
     expose:
       - 5432
-    image: circleci/postgres:9.6-alpine-postgis
+    image: kartoza/postgis:11.0-2.5
     environment:
       - POSTGRES_USER=transmission
       - POSTGRES_PASS=transmission

--- a/compose/int.yml
+++ b/compose/int.yml
@@ -44,6 +44,8 @@ services:
 
   engine_psql:
     image: circleci/postgres:10.10-alpine-ram
+    tmpfs:
+      - /dev/shm/pgdata/data
     expose:
       - 5432
     environment:

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -3,8 +3,6 @@ services:
   psql:
     environment:
       - PGDATA=/dev/shm/pgdata/data
-      # https://www.postgresql.org/docs/11/non-durability.html
-      - EXTRA_CONF=fsync = off\nsynchronous_commit = off\nfull_page_writes = off
     tmpfs:
       - /dev/shm/pgdata/data
 

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -1,5 +1,16 @@
-version: '3.4'
+version: '3.6'
 services:
+  psql:
+    environment:
+      - PGDATA=/dev/shm/pgdata/data
+      # https://www.postgresql.org/docs/11/non-durability.html
+      - EXTRA_CONF=fsync = off\nsynchronous_commit = off\nfull_page_writes = off
+    tmpfs:
+      - /dev/shm/pgdata/data
+
+  redis_db:
+    tmpfs:
+      - /data
 
   runserver:
     build:

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ DJANGO_SETTINGS_MODULE = conf.test_settings
 # -- recommended but optional:
 python_files = tests.py test_*.py *_tests.py
 addopts = -p no:warnings
+junit_family = xunit1


### PR DESCRIPTION
This PR updates all references of Postgres to version 10 in preparation for an upgrade of our RDS instances to version 10.11.

This also moves our local/integration tests to use tmpfs when possible, and uses the settings from https://www.postgresql.org/docs/10/non-durability.html

**NOTE**: without some manual data migration steps, local development data will not be moved over when moving from psql 9 -> 10.