### PR TITLE
Add GZipMiddleware

### DIFF
--- a/apps/shipments/views/permission_link.py
+++ b/apps/shipments/views/permission_link.py
@@ -49,6 +49,12 @@ class PermissionLinkViewSet(mixins.CreateModelMixin,
     def get_queryset(self):
         return self.queryset.filter(shipment_id=self.kwargs['shipment_pk'])
 
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+        # Disable GZipMiddleware for this endpoint to avoid any potential for a BREACH attack
+        response['Content-Encoding'] = 'identity'
+        return response
+
     def create(self, request, *args, **kwargs):
         """
         Creates a link to grant permission to read shipments

--- a/conf/base.py
+++ b/conf/base.py
@@ -179,6 +179,7 @@ MIDDLEWARE = [
     'influxdb_metrics.middleware.InfluxDBRequestMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.gzip.GZipMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     # 'django.middleware.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
Enables gzip compression for response payloads, which should help improve client response times.