### PR TITLE
Document history bug

### DIFF
--- a/tests/profiles-enabled/test_documents.py
+++ b/tests/profiles-enabled/test_documents.py
@@ -363,6 +363,14 @@ class DocumentAPITests(APITestCase):
             assert mock_method.call_count == 1
             assert doc.upload_status == UploadStatus.COMPLETE
 
+            # Test that 'upload complete' is idempotent
+            current_history_count = doc.history.count()
+            response = self.client.post(url, json.dumps(s3_event), content_type="application/json",
+                                        X_NGINX_SOURCE='internal', X_SSL_CLIENT_VERIFY='SUCCESS',
+                                        X_SSL_CLIENT_DN='/CN=document-management-s3-hook.test-internal')
+            assert response.status_code == status.HTTP_204_NO_CONTENT
+            assert doc.history.count() == current_history_count
+
     def test_document_permission(self):
 
         url = reverse('shipment-documents-list', kwargs={'version': 'v1', 'shipment_pk': self.shipments[0].id})


### PR DESCRIPTION
An issue arose where a seemingly random anonymous historical document change was appearing in a stage account. The only modified field was the 'updated_at' field. After looking at the logs, it became clear that the document (image) was being repopulated from Engine's vault into S3, and that S3 upload notification was being sent to Transmission, which was reprocessing it as a Document Create upload event (which would then re-set the document status, resulting in the 'updated_at' modification, and then also re-add the document to the vault).

The fix is to ignore S3 upload events if the Document UploadStatus is already COMPLETE.