### PR TITLE
Remove fields from admin which aren't in the schema.

### DIFF
--- a/apps/shipments/admin/shipment.py
+++ b/apps/shipments/admin/shipment.py
@@ -81,7 +81,16 @@ NON_SCHEMA_FIELDS = [
     'state',
     'delayed',
     'expected_delay_hours',
-    'exception'
+    'exception',
+    'delayed',
+    'expected_delay_hours',
+    'geofences',
+    'assignee_id',
+    'gtx_required',
+    'gtx_validation',
+    'gtx_validation_timestamp',
+    'aftership_tracking',
+    'arrival_est'
 ]
 
 


### PR DESCRIPTION
This removes the fields from the shipment admin page that are not included in the shipment schema.