### PR TITLE
Fix admin page

### DIFF
--- a/apps/admin.py
+++ b/apps/admin.py
@@ -131,7 +131,7 @@ class ShipmentAdminDisplayMixin:
 
 
 class ReadOnlyPermissionMixin:
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
     def has_change_permission(self, request, obj=None):

--- a/apps/shipments/admin/shipment.py
+++ b/apps/shipments/admin/shipment.py
@@ -113,7 +113,7 @@ class ShipmentAdmin(AdminPageSizeMixin,
                 'state',
                 'vault_uri',
                 'device',
-                ('contract_version', 'route_link')
+                'contract_version',
             )
         }),
         ('Shipment Schema Fields', {
@@ -126,6 +126,16 @@ class ShipmentAdmin(AdminPageSizeMixin,
     inlines = [
         AsyncJobInlineTab,
     ]
+
+    def get_fieldsets(self, request, obj=None):
+        if 'history' not in request.scope['path']:
+            if 'route_link' not in self.fieldsets[0][1]['fields']:
+                self.fieldsets[0][1]['fields'] = self.fieldsets[0][1]['fields'] + ('route_link',)
+        elif 'route_link' in self.fieldsets[0][1]['fields']:
+            self.fieldsets[0][1]['fields'] = tuple(
+                [field for field in self.fieldsets[0][1]['fields'] if field != 'route_link']
+            )
+        return self.fieldsets
 
     search_fields = ('id', 'shipper_wallet_id', 'carrier_wallet_id', 'moderator_wallet_id', 'state', 'owner_id',
                      'ship_from_location__name__icontains', 'ship_to_location__name__icontains',
@@ -150,16 +160,6 @@ class ShipmentAdmin(AdminPageSizeMixin,
 
 class HistoricalShipmentAdmin(BaseModelHistory, ShipmentAdmin):
     readonly_fields = [field.name for field in Shipment._meta.get_fields()]
-
-    def get_fieldsets(self, request, obj=None):
-        """
-        Hook for specifying fieldsets.
-        """
-        list_fieldsets = list(self.fieldsets)
-        list_fieldsets[0][1]['fields'] = tuple(list(list_fieldsets[0][1]['fields'])[:-1] + [('contract_version',)])
-        self.fieldsets = tuple(list_fieldsets)
-
-        return self.fieldsets
 
 
 class LocationAdmin(AdminPageSizeMixin, BaseModelHistory):

--- a/apps/shipments/admin/shipment.py
+++ b/apps/shipments/admin/shipment.py
@@ -151,6 +151,16 @@ class ShipmentAdmin(AdminPageSizeMixin,
 class HistoricalShipmentAdmin(BaseModelHistory, ShipmentAdmin):
     readonly_fields = [field.name for field in Shipment._meta.get_fields()]
 
+    def get_fieldsets(self, request, obj=None):
+        """
+        Hook for specifying fieldsets.
+        """
+        list_fieldsets = list(self.fieldsets)
+        list_fieldsets[0][1]['fields'] = tuple(list(list_fieldsets[0][1]['fields'])[:-1] + [('contract_version',)])
+        self.fieldsets = tuple(list_fieldsets)
+
+        return self.fieldsets
+
 
 class LocationAdmin(AdminPageSizeMixin, BaseModelHistory):
 


### PR DESCRIPTION
This branch fixes two things wrong with the admin pages:
- Fixes inline permissions which caused shipments and asyncjobs to be unable to load
- Fixes Historical shipment detail by removing `route_link` from it's fieldsets