### PR TITLE
Feature/renew shipments

### DIFF
--- a/apps/eth/rpc.py
+++ b/apps/eth/rpc.py
@@ -13,7 +13,8 @@ LOG = logging.getLogger('transmission')
 class EventRPCClient(RPCClient):
 
     # pylint:disable=too-many-arguments
-    def subscribe(self, project, version, url=Event.get_event_subscription_url(), interval=5000, events=None):
+    def subscribe(self, project, version, url=Event.get_event_subscription_url(), interval=5000, events=None,
+                  blockheight=0):
         LOG.debug(f'Event subscription with url {url}.')
         log_metric('transmission.info', tags={'method': 'event_rpcclient.subscribe',
                                               'module': __name__})
@@ -23,7 +24,8 @@ class EventRPCClient(RPCClient):
             "project": project,
             "interval": interval,
             "eventNames": events or ["allEvents"],
-            "version": version
+            "version": version,
+            "blockheight": blockheight
         })
 
         if 'success' in result and result['success']:

--- a/apps/eth/rpc.py
+++ b/apps/eth/rpc.py
@@ -33,3 +33,22 @@ class EventRPCClient(RPCClient):
         log_metric('transmission.error', tags={'method': 'event_rpcclient.subscribe', 'code': 'RPCError',
                                                'module': __name__})
         raise RPCError("Invalid response from Engine")
+
+    def unsubscribe(self, project, version, url=Event.get_event_subscription_url()):
+        LOG.debug(f'Event unsubscription with url {url}.')
+        log_metric('transmission.info', tags={'method': 'event_rpcclient.subscribe',
+                                              'module': __name__})
+
+        result = self.call('event.unsubscribe', {
+            "url": url,
+            "project": project,
+            "version": version
+        })
+
+        if 'success' in result and result['success']:
+            if 'subscription' in result:
+                return
+
+        log_metric('transmission.error', tags={'method': 'event_rpcclient.unsubscribe', 'code': 'RPCError',
+                                               'module': __name__})
+        raise RPCError("Invalid response from Engine")

--- a/apps/eth/rpc.py
+++ b/apps/eth/rpc.py
@@ -14,19 +14,23 @@ class EventRPCClient(RPCClient):
 
     # pylint:disable=too-many-arguments
     def subscribe(self, project, version, url=Event.get_event_subscription_url(), interval=5000, events=None,
-                  blockheight=0):
+                  last_block=None):
         LOG.debug(f'Event subscription with url {url}.')
         log_metric('transmission.info', tags={'method': 'event_rpcclient.subscribe',
                                               'module': __name__})
 
-        result = self.call('event.subscribe', {
+        params = {
             "url": url,
             "project": project,
             "interval": interval,
             "eventNames": events or ["allEvents"],
-            "version": version,
-            "blockheight": blockheight
-        })
+            "version": version
+        }
+
+        if last_block:
+            params["lastBlock"] = last_block
+
+        result = self.call('event.subscribe', params)
 
         if 'success' in result and result['success']:
             if 'subscription' in result:

--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -145,7 +145,7 @@ def async_job_fire(self):
             task = None
             try:
                 task = AsyncTask(async_job_id)
-                while cache.ttl("REPLICATE_SHIPMENTS_LOCK") is None:
+                while cache.get("REPLICATE_SHIPMENTS_LOCK", None):
                     LOG.info("Lock for Replicating Shipments currently in use.")
                     time.sleep(15)
                 task.run()

--- a/apps/jobs/tasks.py
+++ b/apps/jobs/tasks.py
@@ -15,7 +15,6 @@ from influxdb_metrics.loader import log_metric
 from shipchain_common.exceptions import RPCError
 
 from .exceptions import WalletInUseException, TransactionCollisionException
-from .models import JobState
 
 LOG = logging.getLogger('transmission')
 
@@ -33,6 +32,7 @@ class AsyncTask:
         self.rpc_client = getattr(module, rpc_class_name)()
 
     def rerun(self):
+        from .models import JobState
 
         self.async_job.state = JobState.PENDING
         self.async_job.save()

--- a/apps/shipments/management/commands/replace_shipments.py
+++ b/apps/shipments/management/commands/replace_shipments.py
@@ -1,0 +1,61 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from django.conf import settings
+from shipchain_common.exceptions import RPCError
+
+from apps.eth.models import Transaction, EthAction
+from apps.eth.rpc import EventRPCClient
+from apps.jobs.models import AsyncJob, JobState
+from apps.jobs.tasks import AsyncTask
+from apps.shipments.models import Shipment
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = 'Moves shipment(s) to etherscan'
+    rpc_client = None
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--shipment_id',
+            type=str,
+            default=None,
+            help='Delete poll instead of closing it',
+        )
+
+    def _convert_shipment(self, shipment):
+        if not self.rpc_client:
+            self.rpc_client = EventRPCClient()
+            try:
+                self.rpc_client.unsubscribe("LOAD", settings.LOAD_VERSION)
+            except RPCError as exc:
+                if 'Error: EventSubscription not found' in exc.detail:
+                    return
+                raise exc
+        for async_job in AsyncJob.objects.filter(shipment=shipment):
+            try:
+                eth_action = EthAction.objects.filter(async_job=async_job).first()
+                if eth_action:
+                    logger.info(f'Deleting Eth Action: {eth_action.transaction_hash}')
+                    eth_action.delete()
+                AsyncTask(async_job.id).rerun()
+            except Exception as exc:
+                print(exc)
+
+    def handle(self, *args, **options):
+        if options['shipment_id']:
+            shipment = Shipment.objects.filter(id=options['shipment_id']).first()
+            if not shipment:
+                raise ValueError(f'Invalid shipment id: {options["shipment_id"]} supplied')
+
+            self._convert_shipment(shipment)
+
+        else:
+            for shipment in Shipment.objects.all():
+                self._convert_shipment(shipment)
+
+        self.rpc_client.subscribe("LOAD", settings.LOAD_VERSION)

--- a/apps/shipments/management/commands/replace_shipments.py
+++ b/apps/shipments/management/commands/replace_shipments.py
@@ -5,9 +5,9 @@ from django.core.management.base import BaseCommand
 from django.conf import settings
 from shipchain_common.exceptions import RPCError
 
-from apps.eth.models import Transaction, EthAction
+from apps.eth.models import EthAction
 from apps.eth.rpc import EventRPCClient
-from apps.jobs.models import AsyncJob, JobState
+from apps.jobs.models import AsyncJob
 from apps.jobs.tasks import AsyncTask
 from apps.shipments.models import Shipment
 
@@ -43,6 +43,7 @@ class Command(BaseCommand):
                     logger.info(f'Deleting Eth Action: {eth_action.transaction_hash}')
                     eth_action.delete()
                 AsyncTask(async_job.id).rerun()
+            # pylint:disable=broad-except
             except Exception as exc:
                 print(exc)
 

--- a/apps/shipments/management/commands/replace_shipments.py
+++ b/apps/shipments/management/commands/replace_shipments.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from django.core.management.base import BaseCommand
 
@@ -45,13 +46,14 @@ class Command(BaseCommand):
                 AsyncTask(async_job.id).rerun()
             # pylint:disable=broad-except
             except Exception as exc:
-                print(exc)
+                logger.error(exc)
 
     def handle(self, *args, **options):
         if options['shipment_id']:
             shipment = Shipment.objects.filter(id=options['shipment_id']).first()
             if not shipment:
-                raise ValueError(f'Invalid shipment id: {options["shipment_id"]} supplied')
+                logger.error(f'Invalid shipment id: {options["shipment_id"]} supplied')
+                sys.exit()
 
             self._convert_shipment(shipment)
 

--- a/apps/shipments/management/commands/replicate_shipments.py
+++ b/apps/shipments/management/commands/replicate_shipments.py
@@ -102,9 +102,12 @@ class Command(BaseCommand):
 
         else:
             shipments = Shipment.objects.all()
+            count = 0
             logger.info(f'Total shipments: {shipments.count()}')
             for shipment in shipments:
+                count += 1
                 self._replicate_shipment(shipment)
+                logger.info(f'{count} of {shipments.count()} shipment(s) replicated/skipped')
 
         logger.info(f'Successful shipments count: {len(self.successful_shipments)}')
         logger.debug(f'Successful shipments: {self.successful_shipments}')

--- a/apps/shipments/management/commands/replicate_shipments.py
+++ b/apps/shipments/management/commands/replicate_shipments.py
@@ -21,8 +21,8 @@ logger.setLevel(settings.LOG_LEVEL)
 class Command(BaseCommand):
     help = 'Replicate shipment related transactions to the sidechain.'
     rpc_client = None
-    successfull_shipments = []
-    unsuccessfull_shipments = []
+    successful_shipments = []
+    unsuccessful_shipments = []
     async_job = None
 
     def add_arguments(self, parser):
@@ -45,16 +45,16 @@ class Command(BaseCommand):
                 if eth_action:
                     logger.info(f'Deleting Eth Action: {eth_action.transaction_hash}')
                     eth_action.delete()
-                if shipment.id not in self.successfull_shipments:
-                    self.successfull_shipments.append(shipment.id)
+                if shipment.id not in self.successful_shipments:
+                    self.successful_shipments.append(shipment.id)
                 self.async_job = async_job
 
             # pylint:disable=broad-except
             except Exception as exc:
                 logger.info(f'Error replicating shipment transactions: {shipment.id}')
-                if shipment.id in self.successfull_shipments:
-                    self.successfull_shipments.remove(shipment.id)
-                self.unsuccessfull_shipments.append(shipment.id)
+                if shipment.id in self.successful_shipments:
+                    self.successful_shipments.remove(shipment.id)
+                self.unsuccessful_shipments.append(shipment.id)
                 logger.error(exc)
 
     def _unsubscribe(self):
@@ -99,9 +99,9 @@ class Command(BaseCommand):
             for shipment in shipments:
                 self._replicate_shipment(shipment)
 
-        logger.info(f'Successful shipments count: {len(self.successfull_shipments)}')
-        logger.debug(f'Successful shipments: {self.successfull_shipments}')
+        logger.info(f'Successful shipments count: {len(self.successful_shipments)}')
+        logger.debug(f'Successful shipments: {self.successful_shipments}')
 
-        logger.warning(f'Unsuccessful shipments count: {len(self.unsuccessfull_shipments)}')
-        logger.warning(f'Unsuccessful shipments: {self.unsuccessfull_shipments}')
+        logger.warning(f'Unsuccessful shipments count: {len(self.unsuccessful_shipments)}')
+        logger.warning(f'Unsuccessful shipments: {self.unsuccessful_shipments}')
         self._resubscribe()

--- a/apps/shipments/management/commands/replicate_shipments.py
+++ b/apps/shipments/management/commands/replicate_shipments.py
@@ -35,8 +35,9 @@ class Command(BaseCommand):
 
     def _replicate_shipment(self, shipment):
         async_jobs = AsyncJob.objects.filter(
-                shipment=shipment, message__type=MessageType.ETH_TRANSACTION,
-                message__body__has_key='cumulativeGasUsed').exclude(message__body__cumulativeGasUsed='0')
+            shipment=shipment, message__type=MessageType.ETH_TRANSACTION,
+            message__body__has_key='cumulativeGasUsed'
+        ).exclude(message__body__cumulativeGasUsed='0')
         logger.info(f'Total async jobs to check for shipment {shipment.id}: {async_jobs.count()}')
         count = 0
         for async_job in async_jobs:
@@ -84,7 +85,7 @@ class Command(BaseCommand):
                            'Need to manually subscribe to latest blockheight')
 
     def handle(self, *args, **options):
-        logger.info(f'Obtaining REPLICATE_SHIPMENTS_LOCK lock')
+        logger.info('Obtaining REPLICATE_SHIPMENTS_LOCK lock')
         cache.set('REPLICATE_SHIPMENTS_LOCK', True, None)
         self._unsubscribe()
         if options['shipment_id']:
@@ -107,6 +108,6 @@ class Command(BaseCommand):
         logger.warning(f'Unsuccessful shipments count: {len(self.unsuccessful_shipments)}')
         logger.warning(f'Unsuccessful shipments: {self.unsuccessful_shipments}')
 
-        logger.info(f'Deleting REPLICATE_SHIPMENTS_LOCK lock')
+        logger.info('Deleting REPLICATE_SHIPMENTS_LOCK lock')
         cache.delete('REPLICATE_SHIPMENTS_LOCK')
         self._resubscribe()

--- a/bin/dc
+++ b/bin/dc
@@ -15,4 +15,9 @@ COMPOUND_COMPOSE=""
 if [ "$ROLE" != "int" ]; then
     COMPOUND_COMPOSE="-f compose/base-services.yml"
 fi
-docker-compose -p $COMPOSE_PROJECT $COMPOUND_COMPOSE -f compose/$ROLE.yml "$@"
+
+UP_FORCED_ARGUMENTS=""
+if [ "$1" == "up" ]; then
+    UP_FORCED_ARGUMENTS="--force-recreate"
+fi
+docker-compose -p $COMPOSE_PROJECT $COMPOUND_COMPOSE -f compose/$ROLE.yml "$@" $UP_FORCED_ARGUMENTS

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -26,6 +26,13 @@ services:
     image: transmission-django-dev
     volumes:
       - ../:/app
+    networks:
+      default:
+        aliases:
+          - transmission-django-shell
+      portal:
+        aliases:
+          - transmission-django-shell
     links:
       - psql
       - redis_db
@@ -42,6 +49,7 @@ services:
       - INTERNAL_URL=http://transmission-runserver:8000
       - PROFILES_URL #http://profiles-runserver:8000
       - ELASTICSEARCH_URL
+      - LOG_LEVEL
       - AWS_ACCESS_KEY_ID=TEST-DEV-KEY
       - AWS_SECRET_ACCESS_KEY=NON-TRIVIAL-SECRETKEY
     command: "bash"

--- a/tests/profiles-disabled/test_eth.py
+++ b/tests/profiles-disabled/test_eth.py
@@ -149,8 +149,7 @@ class TransactionReceiptTestCase(APITestCase):
             "project": "LOAD",
             "interval": 5000,
             "eventNames": ["allEvents"],
-            "version": "1.1.0",
-            "blockheight": 0
+            "version": "1.1.0"
         }
         full_params = {
             'jsonrpc': '2.0',

--- a/tests/profiles-disabled/test_eth.py
+++ b/tests/profiles-disabled/test_eth.py
@@ -149,7 +149,8 @@ class TransactionReceiptTestCase(APITestCase):
             "project": "LOAD",
             "interval": 5000,
             "eventNames": ["allEvents"],
-            "version": "1.1.0"
+            "version": "1.1.0",
+            "blockheight": 0
         }
         full_params = {
             'jsonrpc': '2.0',


### PR DESCRIPTION
This adds a management command `replicate_shipments` to Transmission.
This is accessed by running `bin/dmg replicate_shipments`, with an optional parameter of `--shipment_id={shipment_id}`
This reruns a shipment's AsyncJobs so that the contracts are renewed on the new chain.