### PR TITLE
Fix builds due to updated icu-libs in Alpine edge repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ ENV LANG C.UTF-8
 ENV PYTHONUNBUFFERED 1
 
 # Essential packages for our app environment
-RUN apk add --no-cache bash wget libpq && \
+RUN apk add --no-cache bash wget libpq icu-libs && \
     apk add --no-cache \
             --repository http://dl-3.alpinelinux.org/alpine/edge/main/ \
             --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
             libcrypto1.1 binutils libcurl libwebp zstd-libs libjpeg-turbo libpng openjpeg libwebp pcre libxml2 \
-            lcms2-dev fontconfig openexr-dev portablexdr-dev cfitsio icu-libs  && \
+            lcms2-dev fontconfig openexr-dev portablexdr-dev cfitsio && \
     rm -f /usr/lib/libturbojpeg.so* /usr/lib/libwebpmux.so* /usr/lib/libwebpdemux.so* /usr/lib/libwebpdecoder.so* /usr/lib/libpoppler-cpp.so* && \
     wget https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py && \
     python get-poetry.py --version 1.0.9 && \


### PR DESCRIPTION
The package `icu-libs` was previously installed via the Edge repository, but that package's version was incremented and is no longer compatible with the `postgresql` package installed from the 3.12 repository.  The icu-libs package needs to be removed from the installation step when the edge repository is in use and should instead be installed from the 3.12 repository.