### PR TITLE
Increase channel capacity and reduce expiry from defaults

### DIFF
--- a/conf/base.py
+++ b/conf/base.py
@@ -245,6 +245,8 @@ CHANNEL_LAYERS = {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [os.environ.get('REDIS_URL', default='redis://:redis_pass@redis_db:6379/1')],
+            "capacity": 1500,
+            "expiry": 10,
         },
     },
 }


### PR DESCRIPTION
The default capacity is 100 messages and the default message expiration time is 60 seconds. So if the the channel is never read within these capacity/time constraints, it will fill up.  This increases the capacity limit while decreasing the expiration time in Transmission to prevent channels from becoming overloaded.