### PR TITLE
Change which id is supplied to aftership

### DIFF
--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -185,7 +185,8 @@ def shipment_quickadd_tracking_changed(sender, instance, changed_fields, **kwarg
                                              carrier_abbv=tracking_data['slug'])
         instance.refresh_from_db(fields=['shippers_reference', 'carrier_abbv'])
 
-        SNSClient().aftership_tracking_update(instance, tracking_data['id'])
+        # pylint: disable=protected-access
+        SNSClient().aftership_tracking_update(instance, tracking_data['id'], instance.updated_by)
 
 
 @receiver(post_save_changed, sender=Shipment, fields=['device', 'state', 'geofences'],

--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -185,7 +185,6 @@ def shipment_quickadd_tracking_changed(sender, instance, changed_fields, **kwarg
                                              carrier_abbv=tracking_data['slug'])
         instance.refresh_from_db(fields=['shippers_reference', 'carrier_abbv'])
 
-        # pylint: disable=protected-access
         SNSClient().aftership_tracking_update(instance, tracking_data['id'], instance.updated_by)
 
 

--- a/apps/sns.py
+++ b/apps/sns.py
@@ -19,10 +19,10 @@ class SNSClient:
             }
         )
 
-    def aftership_tracking_update(self, shipment, aftership_id):
+    def aftership_tracking_update(self, shipment, aftership_id, owner_id):
         self._publish(
             SNSClient.MessageType.AFTERSHIP_UPDATE,
-            ownerId=shipment.owner_id,
+            ownerId=owner_id,
             aftershipTrackingId=aftership_id,
             shipmentId=shipment.id
         )

--- a/tests/profiles_enabled/shipments/test_sns.py
+++ b/tests/profiles_enabled/shipments/test_sns.py
@@ -85,7 +85,7 @@ class TestSNS:
         assert json.loads(shipment_message[0]['Message'])['id'] == shipment.id
         assert json.loads(aftership_message[0]['Message'])['shipmentId'] == shipment.id
         assert json.loads(aftership_message[0]['Message'])['aftershipTrackingId'] == 'id-from-aftership'
-        assert json.loads(aftership_message[0]['Message'])['ownerId'] == shipment.owner_id
+        assert json.loads(aftership_message[0]['Message'])['ownerId'] == shipment.updated_by
 
         messages = sqs_queue.receive_messages(MaxNumberOfMessages=1)
         assert len(messages) == 0  # Queue should be clear


### PR DESCRIPTION
This branch changes the id sent to the aftership queue. Instead of using the `owner_id`, which can return an `organization_id` instead of a `user_id`, a shipment's `updated_by` is used, as that will point to the original creator of the shipment.