### PR TITLE
Modify carrier abbv creation

### DIFF
--- a/apps/shipments/serializers/shipment.py
+++ b/apps/shipments/serializers/shipment.py
@@ -18,7 +18,6 @@ import json
 from collections import OrderedDict
 from datetime import datetime, timezone
 
-import requests
 from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.db import transaction
@@ -276,15 +275,6 @@ class ShipmentCreateSerializer(ShipmentSerializer):
             if gtx_required and not self.user.has_perm('gtx.shipment_use'):
                 raise PermissionDenied('User does not have access to enable GTX for this shipment')
         return gtx_required
-
-    def validate_quickadd_tracking(self, quickadd_tracking):
-        response = requests.post(f'{settings.AFTERSHIP_URL}couriers/detect',
-                                 headers={'aftership-api-key': settings.AFTERSHIP_API_KEY},
-                                 json={'tracking': {'tracking_number': quickadd_tracking}})
-        if not response.ok:
-            raise serializers.ValidationError('Invalid quickadd_tracking value')
-
-        return quickadd_tracking
 
 
 class ShipmentUpdateSerializer(ShipmentSerializer):

--- a/apps/shipments/signals.py
+++ b/apps/shipments/signals.py
@@ -172,7 +172,7 @@ def shipment_quickadd_tracking_changed(sender, instance, changed_fields, **kwarg
         response = requests.post(f'{settings.AFTERSHIP_URL}couriers/detect',
                                  headers={'aftership-api-key': settings.AFTERSHIP_API_KEY},
                                  json={'tracking': {'tracking_number': instance.quickadd_tracking}})
-        if not response.ok:
+        if not response.ok or not response.json()['data']['couriers']:
             raise ValidationError('Invalid quickadd_tracking value')
 
         slug = response.json()['data']['couriers'][0]['name']

--- a/apps/sns.py
+++ b/apps/sns.py
@@ -19,12 +19,13 @@ class SNSClient:
             }
         )
 
-    def aftership_tracking_update(self, shipment, aftership_id, owner_id):
+    def aftership_tracking_update(self, shipment, aftership_id):
         self._publish(
             SNSClient.MessageType.AFTERSHIP_UPDATE,
-            ownerId=owner_id,
+            ownerId=shipment.updated_by,
             aftershipTrackingId=aftership_id,
-            shipmentId=shipment.id
+            shipmentId=shipment.id,
+            carrierType=shipment.carrier_abbv
         )
 
     def shipment_update(self, shipment):

--- a/tests/profiles_enabled/shipments/test_shipments.py
+++ b/tests/profiles_enabled/shipments/test_shipments.py
@@ -73,6 +73,15 @@ class TestShipmentAftershipQuickadd:
         return mock_successful_wallet_owner_calls
 
     @pytest.fixture
+    def mock_aftership_validation_no_couriers(self, mock_successful_wallet_owner_calls):
+        mock_successful_wallet_owner_calls.register_uri(
+            mock_successful_wallet_owner_calls.POST,
+            f'{settings.AFTERSHIP_URL}couriers/detect',
+            body=json.dumps({'data': {'couriers': []}}),
+        )
+        return mock_successful_wallet_owner_calls
+
+    @pytest.fixture
     def mock_aftership_create_success(self, mock_aftership_validation_succeess):
         mock_aftership_validation_succeess.register_uri(
             mock_aftership_validation_succeess.POST,
@@ -134,6 +143,12 @@ class TestShipmentAftershipQuickadd:
         response = client_alice.post(self.create_url, self.base_create_attributes)
         AssertionHelper.HTTP_400(response, error='Invalid quickadd_tracking value')
         mock_aftership_validation_failure.assert_calls(assertions_aftership_validation)
+
+    def test_quickadd_no_couriers(self, client_alice, mock_aftership_validation_no_couriers,
+                                      assertions_aftership_validation):
+        response = client_alice.post(self.create_url, self.base_create_attributes)
+        AssertionHelper.HTTP_400(response, error='Invalid quickadd_tracking value')
+        mock_aftership_validation_no_couriers.assert_calls(assertions_aftership_validation)
 
 
 class TestShipmentsList:

--- a/tests/profiles_enabled/shipments/test_shipments.py
+++ b/tests/profiles_enabled/shipments/test_shipments.py
@@ -57,9 +57,11 @@ class TestShipmentAftershipQuickadd:
 
     @pytest.fixture
     def mock_aftership_validation_succeess(self, mock_successful_wallet_owner_calls):
-        mock_successful_wallet_owner_calls.register_uri(mock_successful_wallet_owner_calls.POST,
-                                                        f'{settings.AFTERSHIP_URL}couriers/detect',
-                                                        )
+        mock_successful_wallet_owner_calls.register_uri(
+            mock_successful_wallet_owner_calls.POST,
+            f'{settings.AFTERSHIP_URL}couriers/detect',
+            body=json.dumps({'data': {'couriers': [{'name': 'aftership-slug'}]}}),
+        )
         return mock_successful_wallet_owner_calls
 
     @pytest.fixture


### PR DESCRIPTION
Change the flow of the quickadd shipment, so that the `quickadd_tracking` field is checked in the signal.
The `carrier_abbv` field is then modified based on the response from the `detect/courier` request.